### PR TITLE
Add accept/request changes to public quote page

### DIFF
--- a/prisma/migrations/20260220174923_customer_quotation_interaction/migration.sql
+++ b/prisma/migrations/20260220174923_customer_quotation_interaction/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "quotes" ADD COLUMN     "customerMessage" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -377,6 +377,7 @@ model Quote {
   totalAmount    Float     @default(0)
   notes          String?
   publicToken    String?
+  customerMessage String?
   convertedToId  String?
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt

--- a/src/app/(authenticated)/page.tsx
+++ b/src/app/(authenticated)/page.tsx
@@ -4,11 +4,12 @@ import { SETTING_KEYS } from "@/features/settings/Schema/settingsSchema";
 import { getVehiclesDueForService } from "@/features/vehicles/Actions/predictedMaintenanceActions";
 import { getInspectionsPaginated } from "@/features/inspections/Actions/inspectionActions";
 import { getQuoteRequests } from "@/features/inspections/Actions/quoteRequestActions";
+import { getQuoteResponses } from "@/features/quotes/Actions/quoteResponseActions";
 import { DashboardClient } from "./dashboard-client";
 import { PageHeader } from "@/components/page-header";
 
 export default async function DashboardPage() {
-  const [result, settingsResult, remindersResult, maintenanceResult, inProgressResult, completedResult, quoteRequestsResult] = await Promise.all([
+  const [result, settingsResult, remindersResult, maintenanceResult, inProgressResult, completedResult, quoteRequestsResult, quoteResponsesResult] = await Promise.all([
     getDashboardStats(),
     getSettings([SETTING_KEYS.CURRENCY_CODE, SETTING_KEYS.UNIT_SYSTEM]),
     getUpcomingReminders(),
@@ -16,6 +17,7 @@ export default async function DashboardPage() {
     getInspectionsPaginated({ status: "in_progress", pageSize: 5 }),
     getInspectionsPaginated({ status: "completed", pageSize: 5 }),
     getQuoteRequests(),
+    getQuoteResponses(),
   ]);
 
   if (!result.success || !result.data) {
@@ -48,6 +50,7 @@ export default async function DashboardPage() {
           inProgressInspections={inProgressResult.success && inProgressResult.data ? inProgressResult.data.records : []}
           completedInspections={completedResult.success && completedResult.data ? completedResult.data.records : []}
           quoteRequests={quoteRequestsResult.success && quoteRequestsResult.data ? quoteRequestsResult.data : []}
+          quoteResponses={quoteResponsesResult.success && quoteResponsesResult.data ? quoteResponsesResult.data : []}
         />
       </div>
     </>

--- a/src/app/(authenticated)/quotes/[id]/page.tsx
+++ b/src/app/(authenticated)/quotes/[id]/page.tsx
@@ -29,14 +29,14 @@ export default async function QuoteDetailPage({
 
   if (!result.success || !result.data) {
     return (
-      <>
+      <div className="flex h-svh flex-col overflow-hidden">
         <PageHeader />
         <div className="flex h-[50vh] items-center justify-center">
           <p className="text-muted-foreground">
             {result.error || "Quote not found"}
           </p>
         </div>
-      </>
+      </div>
     );
   }
 
@@ -60,7 +60,7 @@ export default async function QuoteDetailPage({
   const organizationId = authContext?.organizationId || "";
 
   return (
-    <>
+    <div className="flex h-svh flex-col overflow-hidden">
       <PageHeader />
       <QuotePageClient
         quote={result.data}
@@ -105,6 +105,6 @@ export default async function QuoteDetailPage({
           })
         )}
       />
-    </>
+    </div>
   );
 }

--- a/src/app/api/public/quote-response/route.ts
+++ b/src/app/api/public/quote-response/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { respondToQuote } from "@/features/quotes/Actions/quoteResponseActions";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const result = await respondToQuote(body);
+    return NextResponse.json(result, { status: result.success ? 200 : 400 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to process quote response";
+    return NextResponse.json({ success: false, error: message }, { status: 400 });
+  }
+}

--- a/src/features/quotes/Actions/quoteResponseActions.ts
+++ b/src/features/quotes/Actions/quoteResponseActions.ts
@@ -1,0 +1,96 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { withAuth } from "@/lib/with-auth";
+import { PermissionAction, PermissionSubject } from "@/lib/permissions";
+import { z } from "zod";
+
+const respondToQuoteSchema = z.object({
+  quoteId: z.string().min(1),
+  publicToken: z.string().min(1),
+  action: z.enum(["accepted", "changes_requested"]),
+  message: z.string().optional(),
+});
+
+/**
+ * Public action — no auth required.
+ * Customer accepts or requests changes on a shared quote page.
+ */
+export async function respondToQuote(input: unknown) {
+  const data = respondToQuoteSchema.parse(input);
+
+  // Verify the quote exists and the token matches
+  const quote = await db.quote.findFirst({
+    where: { id: data.quoteId, publicToken: data.publicToken },
+  });
+  if (!quote) {
+    return { success: false, error: "Quote not found" };
+  }
+
+  // Only allow response on quotes that are draft or sent
+  if (!["draft", "sent"].includes(quote.status)) {
+    return { success: false, error: "This quote can no longer be updated" };
+  }
+
+  await db.quote.update({
+    where: { id: data.quoteId },
+    data: {
+      status: data.action,
+      customerMessage: data.message || null,
+    },
+  });
+
+  return { success: true };
+}
+
+/**
+ * Authenticated — fetch quotes with customer responses (accepted / changes_requested).
+ */
+export async function getQuoteResponses() {
+  return withAuth(async ({ organizationId }) => {
+    const quotes = await db.quote.findMany({
+      where: {
+        organizationId,
+        status: { in: ["accepted", "changes_requested"] },
+      },
+      select: {
+        id: true,
+        title: true,
+        quoteNumber: true,
+        status: true,
+        customerMessage: true,
+        totalAmount: true,
+        updatedAt: true,
+        vehicleId: true,
+        customer: {
+          select: { name: true },
+        },
+        vehicle: {
+          select: { id: true, make: true, model: true, year: true },
+        },
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 20,
+    });
+    return quotes;
+  }, { requiredPermissions: [{ action: PermissionAction.READ, subject: PermissionSubject.QUOTES }] });
+}
+
+/**
+ * Authenticated — acknowledge a customer response by setting the quote back to a working status.
+ */
+export async function acknowledgeQuoteResponse(quoteId: string) {
+  return withAuth(async ({ organizationId }) => {
+    const quote = await db.quote.findFirst({
+      where: { id: quoteId, organizationId },
+    });
+    if (!quote) throw new Error("Quote not found");
+
+    await db.quote.update({
+      where: { id: quoteId },
+      data: { status: "draft", customerMessage: null },
+    });
+
+    return { success: true };
+  }, { requiredPermissions: [{ action: PermissionAction.UPDATE, subject: PermissionSubject.QUOTES }] });
+}

--- a/src/features/quotes/Schema/quoteSchema.ts
+++ b/src/features/quotes/Schema/quoteSchema.ts
@@ -18,7 +18,7 @@ export const quoteLaborSchema = z.object({
 export const createQuoteSchema = z.object({
   title: z.string().min(1, "Title is required"),
   description: z.string().optional(),
-  status: z.enum(["draft", "sent", "accepted", "rejected", "expired", "converted"]).default("draft"),
+  status: z.enum(["draft", "sent", "accepted", "rejected", "expired", "converted", "changes_requested"]).default("draft"),
   validUntil: z.string().optional(),
   customerId: z.string().optional(),
   vehicleId: z.string().optional(),


### PR DESCRIPTION
Customers can now respond to quotes directly from the shared public link.

- Add "Accept Quote" and "Request Changes" buttons to the public quote page
- Store customer response status and message on the Quote model (customerMessage field)
- Add changes_requested status with color handling across the app
- Show customer responses in the dashboard with dismiss and convert-to-work-order actions
- Display customer message with timestamp in the quote detail sidebar with "Mark as Resolved" button
- Move "Convert to Work Order" to the top of the quote sidebar
- Fix quote detail page layout so the header stays sticky when scrolling