### PR TITLE
Limit organization creation per plan in cloud mode

### DIFF
--- a/src/features/team/Actions/createNewOrganization.ts
+++ b/src/features/team/Actions/createNewOrganization.ts
@@ -3,12 +3,26 @@
 import { cookies } from "next/headers";
 import { db } from "@/lib/db";
 import { withAuth } from "@/lib/with-auth";
+import { isCloudMode, getMaxOrganizations } from "@/lib/features";
 import { createOrganizationSchema } from "../Schema/teamSchema";
 import { revalidatePath } from "next/cache";
 
 export async function createNewOrganization(input: unknown) {
   return withAuth(async ({ userId }) => {
     const data = createOrganizationSchema.parse(input);
+
+    if (isCloudMode()) {
+      const ownedCount = await db.organizationMember.count({
+        where: { userId, role: "owner" },
+      });
+      const maxOrgs = await getMaxOrganizations(userId);
+
+      if (ownedCount >= maxOrgs) {
+        throw new Error(
+          `You have reached the maximum number of organizations (${maxOrgs}) for your plan. Upgrade to create more.`,
+        );
+      }
+    }
 
     const org = await db.$transaction(async (tx) => {
       const created = await tx.organization.create({


### PR DESCRIPTION
- Added maxOrganizations to plan features (Free: 1, Pro: 3, Enterprise: 10)
- createNewOrganization now checks the user's org count against their best plan limit before allowing creation
- Self-hosted mode is unaffected (unlimited)