### PR TITLE
Add reminders page, expand search, and fix inspection creation

### DIFF
--- a/src/app/(authenticated)/dashboard-client.tsx
+++ b/src/app/(authenticated)/dashboard-client.tsx
@@ -520,7 +520,7 @@ export function DashboardClient({
                     <div
                       key={r.id}
                       className="flex items-center justify-between px-5 py-3 cursor-pointer hover:bg-muted/50 transition-colors"
-                      onClick={() => router.push(`/vehicles/${r.vehicle.id}`)}
+                      onClick={() => router.push(`/vehicles/${r.vehicle.id}?tab=reminders`)}
                     >
                       <div className="flex items-center gap-3 min-w-0">
                         <div className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${

--- a/src/features/inspections/Actions/inspectionActions.ts
+++ b/src/features/inspections/Actions/inspectionActions.ts
@@ -139,13 +139,19 @@ export async function createInspection(input: unknown) {
     });
     if (!template) throw new Error("Template not found");
 
+    // Look up technician linked to current user
+    const technician = await db.technician.findFirst({
+      where: { memberId: userId, organizationId, isActive: true },
+      select: { id: true },
+    });
+
     const inspection = await db.$transaction(async (tx) => {
       const created = await tx.inspection.create({
         data: {
           vehicleId: data.vehicleId,
           templateId: data.templateId,
           mileage: data.mileage,
-          technicianId: userId,
+          technicianId: technician?.id ?? null,
           organizationId,
         },
       });

--- a/src/features/search/Actions/searchActions.ts
+++ b/src/features/search/Actions/searchActions.ts
@@ -26,7 +26,7 @@ export async function getRecentCustomers() {
 export async function globalSearch(query: string) {
   return withAuth(async ({ organizationId }) => {
     if (!query || query.trim().length < 2) {
-      return { vehicles: [], customers: [], services: [], parts: [], quotes: [] };
+      return { vehicles: [], customers: [], services: [], parts: [], quotes: [], reminders: [], inspections: [] };
     }
 
     const q = query.trim();
@@ -42,7 +42,7 @@ export async function globalSearch(query: string) {
       vehicleOr.push({ year: Number(q) });
     }
 
-    const [vehicles, customers, services, parts, quotes] = await Promise.all([
+    const [vehicles, customers, services, parts, quotes, reminders, inspections] = await Promise.all([
       db.vehicle.findMany({
         where: { organizationId, OR: vehicleOr },
         select: {
@@ -133,8 +133,64 @@ export async function globalSearch(query: string) {
         },
         take: 10,
       }),
+      db.reminder.findMany({
+        where: {
+          vehicle: { organizationId },
+          OR: [
+            { title: { contains: q, mode } },
+            { description: { contains: q, mode } },
+            { vehicle: { make: { contains: q, mode } } },
+            { vehicle: { model: { contains: q, mode } } },
+            { vehicle: { licensePlate: { contains: q, mode } } },
+          ],
+        },
+        select: {
+          id: true,
+          title: true,
+          dueDate: true,
+          isCompleted: true,
+          vehicle: {
+            select: {
+              id: true,
+              make: true,
+              model: true,
+              year: true,
+              licensePlate: true,
+            },
+          },
+        },
+        take: 10,
+      }),
+      db.inspection.findMany({
+        where: {
+          vehicle: { organizationId },
+          OR: [
+            { template: { name: { contains: q, mode } } },
+            { notes: { contains: q, mode } },
+            { vehicle: { make: { contains: q, mode } } },
+            { vehicle: { model: { contains: q, mode } } },
+            { vehicle: { licensePlate: { contains: q, mode } } },
+          ],
+        },
+        select: {
+          id: true,
+          status: true,
+          createdAt: true,
+          template: { select: { name: true } },
+          vehicle: {
+            select: {
+              id: true,
+              make: true,
+              model: true,
+              year: true,
+              licensePlate: true,
+            },
+          },
+        },
+        take: 10,
+      }),
     ]);
 
-    return { vehicles, customers, services, parts, quotes };
+    return { vehicles, customers, services, parts, quotes, reminders, inspections };
   }, { requiredPermissions: [{ action: PermissionAction.READ, subject: PermissionSubject.DASHBOARD }] });
 }

--- a/src/features/search/Components/SearchCommand.tsx
+++ b/src/features/search/Components/SearchCommand.tsx
@@ -10,7 +10,7 @@ import {
   CommandGroup,
   CommandItem,
 } from "@/components/ui/command";
-import { Car, FileText, Package, Settings, Users, Wrench } from "lucide-react";
+import { Bell, Car, ClipboardCheck, FileText, Package, Settings, Users, Wrench } from "lucide-react";
 import { globalSearch, getRecentCustomers } from "@/features/search/Actions/searchActions";
 
 interface SearchResult {
@@ -51,6 +51,32 @@ interface SearchResult {
     title: string;
     quoteNumber: string | null;
     status: string;
+  }[];
+  reminders: {
+    id: string;
+    title: string;
+    dueDate: Date | null;
+    isCompleted: boolean;
+    vehicle: {
+      id: string;
+      make: string;
+      model: string;
+      year: number;
+      licensePlate: string | null;
+    };
+  }[];
+  inspections: {
+    id: string;
+    status: string;
+    createdAt: Date;
+    template: { name: string };
+    vehicle: {
+      id: string;
+      make: string;
+      model: string;
+      year: number;
+      licensePlate: string | null;
+    };
   }[];
 }
 
@@ -101,7 +127,7 @@ export function SearchCommand() {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchResult>({ vehicles: [], customers: [], services: [], parts: [], quotes: [] });
+  const [results, setResults] = useState<SearchResult>({ vehicles: [], customers: [], services: [], parts: [], quotes: [], reminders: [], inspections: [] });
   const [loading, setLoading] = useState(false);
   const [recentCustomers, setRecentCustomers] = useState<RecentCustomer[]>([]);
   const recentFetchedRef = useRef(false);
@@ -136,7 +162,7 @@ export function SearchCommand() {
   useEffect(() => {
     if (!debouncedQuery || debouncedQuery.length < 2) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- clearing results on query change is intentional
-      setResults({ vehicles: [], customers: [], services: [], parts: [], quotes: [] });
+      setResults({ vehicles: [], customers: [], services: [], parts: [], quotes: [], reminders: [], inspections: [] });
       setLoading(false);
       return;
     }
@@ -167,7 +193,7 @@ export function SearchCommand() {
   );
 
   const hasQuery = debouncedQuery.length >= 2;
-  const hasResults = results.vehicles.length > 0 || results.customers.length > 0 || results.services.length > 0 || results.parts.length > 0 || results.quotes.length > 0;
+  const hasResults = results.vehicles.length > 0 || results.customers.length > 0 || results.services.length > 0 || results.parts.length > 0 || results.quotes.length > 0 || results.reminders.length > 0 || results.inspections.length > 0;
   const matchedSettings = hasQuery ? filterSettings(debouncedQuery) : SEARCHABLE_SETTINGS;
   const showDefault = !hasQuery;
 
@@ -307,6 +333,47 @@ export function SearchCommand() {
                       <span>{p.name}</span>
                       <span className="text-xs text-muted-foreground">
                         {[p.partNumber, `${p.quantity} in stock`].filter(Boolean).join(" · ")}
+                      </span>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            {results.reminders.length > 0 && (
+              <CommandGroup heading="Reminders">
+                {results.reminders.map((r) => (
+                  <CommandItem
+                    key={r.id}
+                    value={`${r.title} ${r.vehicle.make} ${r.vehicle.model} ${r.vehicle.licensePlate || ""}`}
+                    onSelect={() => handleSelect(`/vehicles/${r.vehicle.id}?tab=reminders`)}
+                  >
+                    <Bell className="mr-2 h-4 w-4 text-muted-foreground" />
+                    <div className="flex flex-col">
+                      <span>{r.title}{r.isCompleted && <span className="ml-1.5 text-muted-foreground line-through">(done)</span>}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {`${r.vehicle.year} ${r.vehicle.make} ${r.vehicle.model}`}
+                        {r.vehicle.licensePlate && ` · ${r.vehicle.licensePlate}`}
+                      </span>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            {results.inspections.length > 0 && (
+              <CommandGroup heading="Inspections">
+                {results.inspections.map((insp) => (
+                  <CommandItem
+                    key={insp.id}
+                    value={`${insp.template.name} ${insp.vehicle.make} ${insp.vehicle.model} ${insp.vehicle.licensePlate || ""}`}
+                    onSelect={() => handleSelect(`/inspections/${insp.id}`)}
+                  >
+                    <ClipboardCheck className="mr-2 h-4 w-4 text-muted-foreground" />
+                    <div className="flex flex-col">
+                      <span>{insp.template.name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {`${insp.vehicle.year} ${insp.vehicle.make} ${insp.vehicle.model}`}
+                        {insp.vehicle.licensePlate && ` · ${insp.vehicle.licensePlate}`}
+                        {` · ${insp.status}`}
                       </span>
                     </div>
                   </CommandItem>

--- a/src/features/vehicles/Components/RemindersPageClient.tsx
+++ b/src/features/vehicles/Components/RemindersPageClient.tsx
@@ -290,7 +290,7 @@ export function RemindersPageClient({ reminders, vehicles, unitSystem }: Reminde
                       <span className="text-xs text-muted-foreground">
                         <span
                           className="hover:underline cursor-pointer"
-                          onClick={() => router.push(`/vehicles/${r.vehicle.id}`)}
+                          onClick={() => router.push(`/vehicles/${r.vehicle.id}?tab=reminders`)}
                         >
                           {r.vehicle.year} {r.vehicle.make} {r.vehicle.model}
                           {r.vehicle.licensePlate && ` · ${r.vehicle.licensePlate}`}


### PR DESCRIPTION
- Add dedicated /reminders page with vehicle selector, calendar picker, and CRUD                                 
- Add reminders and inspections to global search (Ctrl+K)       
- Fix inspection creation FK error (`technicianId` was using `userId` instead of looking up technician by `memberId`)