### PR TITLE
Add engine code field to vehicles

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/messages/de/vehicles.json
+++ b/messages/de/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Schaltgetriebe",
     "cvt": "CVT",
     "engineSize": "Hubraum",
+    "engineCode": "Motorcode",
     "makeMarine": "Hersteller *",
     "mileageMarine": "Betriebsstunden",
     "transmissionMarine": "Motortyp",

--- a/messages/en/vehicles.json
+++ b/messages/en/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Manual",
     "cvt": "CVT",
     "engineSize": "Engine Size",
+    "engineCode": "Engine Code",
     "makeMarine": "Manufacturer *",
     "mileageMarine": "Engine Hours",
     "transmissionMarine": "Engine Type",

--- a/messages/es/vehicles.json
+++ b/messages/es/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Manual",
     "cvt": "CVT",
     "engineSize": "Tamano del motor",
+    "engineCode": "Código del motor",
     "makeMarine": "Fabricante *",
     "mileageMarine": "Horas de Motor",
     "transmissionMarine": "Tipo de Motor",

--- a/messages/fr/vehicles.json
+++ b/messages/fr/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Manuelle",
     "cvt": "CVT",
     "engineSize": "Cylindrée",
+    "engineCode": "Code moteur",
     "makeMarine": "Fabricant *",
     "mileageMarine": "Heures Moteur",
     "transmissionMarine": "Type de Moteur",

--- a/messages/it/vehicles.json
+++ b/messages/it/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Manuale",
     "cvt": "CVT",
     "engineSize": "Cilindrata",
+    "engineCode": "Codice motore",
     "makeMarine": "Costruttore *",
     "mileageMarine": "Ore Motore",
     "transmissionMarine": "Tipo di Motore",

--- a/messages/lt/vehicles.json
+++ b/messages/lt/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Mechaninė",
     "cvt": "CVT",
     "engineSize": "Variklio tūris",
+    "engineCode": "Variklio kodas",
     "makeMarine": "Gamintojas *",
     "mileageMarine": "Variklio valandos",
     "transmissionMarine": "Variklio tipas",

--- a/messages/nb/vehicles.json
+++ b/messages/nb/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Manuell",
     "cvt": "CVT",
     "engineSize": "Motorstorrelse",
+    "engineCode": "Motorkode",
     "makeMarine": "Produsent *",
     "mileageMarine": "Motortimer",
     "transmissionMarine": "Motortype",

--- a/messages/nl/vehicles.json
+++ b/messages/nl/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Handgeschakeld",
     "cvt": "CVT",
     "engineSize": "Motorinhoud",
+    "engineCode": "Motorcode",
     "makeMarine": "Fabrikant *",
     "mileageMarine": "Motoruren",
     "transmissionMarine": "Motortype",

--- a/messages/pl/vehicles.json
+++ b/messages/pl/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Manualna",
     "cvt": "CVT",
     "engineSize": "Pojemność silnika",
+    "engineCode": "Kod silnika",
     "makeMarine": "Producent *",
     "mileageMarine": "Godziny Pracy Silnika",
     "transmissionMarine": "Typ Silnika",

--- a/messages/pt-BR/vehicles.json
+++ b/messages/pt-BR/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Manual",
     "cvt": "CVT",
     "engineSize": "Cilindrada",
+    "engineCode": "Código do motor",
     "makeMarine": "Fabricante *",
     "mileageMarine": "Horas de Motor",
     "transmissionMarine": "Tipo de Motor",

--- a/messages/ru/vehicles.json
+++ b/messages/ru/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Механическая",
     "cvt": "Вариатор",
     "engineSize": "Объём двигателя",
+    "engineCode": "Код двигателя",
     "makeMarine": "Производитель *",
     "mileageMarine": "Моточасы",
     "transmissionMarine": "Тип Двигателя",

--- a/messages/tr/vehicles.json
+++ b/messages/tr/vehicles.json
@@ -306,6 +306,7 @@
     "manual": "Manuel",
     "cvt": "CVT",
     "engineSize": "Motor Hacmi",
+    "engineCode": "Motor Kodu",
     "makeMarine": "Üretici *",
     "mileageMarine": "Motor Saatleri",
     "transmissionMarine": "Motor Tipi",

--- a/prisma/migrations/20260503000000_vehicle_engine_code/migration.sql
+++ b/prisma/migrations/20260503000000_vehicle_engine_code/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "vehicles" ADD COLUMN "engineCode" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -142,6 +142,7 @@ model Vehicle {
   fuelType               String?              @default("gasoline")
   transmission           String?              @default("automatic")
   engineSize             String?
+  engineCode             String?
   purchaseDate           DateTime?
   purchasePrice          Float?
   imageUrl               String?

--- a/src/app/(authenticated)/vehicles/[id]/vehicle-detail-client.tsx
+++ b/src/app/(authenticated)/vehicles/[id]/vehicle-detail-client.tsx
@@ -166,6 +166,7 @@ interface VehicleDetail {
   fuelType: string | null
   transmission: string | null
   engineSize: string | null
+  engineCode: string | null
   purchaseDate: Date | null
   purchasePrice: number | null
   imageUrl: string | null
@@ -591,8 +592,14 @@ export function VehicleDetailClient({
                 {vehicle.licensePlate && <span className="font-mono">{vehicle.licensePlate}</span>}
                 {vehicle.vin && (
                   <>
-                    <span>&middot;</span>
+                    {vehicle.licensePlate && <span>&middot;</span>}
                     <span className="font-mono">{vehicle.vin}</span>
+                  </>
+                )}
+                {vehicle.engineCode && (
+                  <>
+                    {(vehicle.licensePlate || vehicle.vin) && <span>&middot;</span>}
+                    <span className="font-mono">{vehicle.engineCode}</span>
                   </>
                 )}
               </div>

--- a/src/app/(authenticated)/vehicles/vehicles-client.tsx
+++ b/src/app/(authenticated)/vehicles/vehicles-client.tsx
@@ -60,6 +60,7 @@ interface Vehicle {
   fuelType: string | null
   transmission: string | null
   engineSize: string | null
+  engineCode: string | null
   imageUrl: string | null
   customerId: string | null
   customer: { id: string; name: string; company: string | null } | null

--- a/src/features/customers/Components/CustomerForm.tsx
+++ b/src/features/customers/Components/CustomerForm.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -86,6 +87,9 @@ export function CustomerForm({ open, onOpenChange, customer, onCreated }: Custom
           <DialogTitle>
             {customer ? t("editTitle") : t("addTitle")}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            {customer ? t("editTitle") : t("addTitle")}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/features/vehicles/Actions/vehicleActions.ts
+++ b/src/features/vehicles/Actions/vehicleActions.ts
@@ -194,6 +194,7 @@ export async function updateVehicle(input: unknown) {
         fuelType: data.fuelType !== undefined ? (data.fuelType || null) : undefined,
         transmission: data.transmission !== undefined ? (data.transmission || null) : undefined,
         engineSize: data.engineSize !== undefined ? (data.engineSize || null) : undefined,
+        engineCode: data.engineCode !== undefined ? (data.engineCode || null) : undefined,
         purchaseDate: data.purchaseDate ? new Date(data.purchaseDate) : undefined,
         customerId: data.customerId !== undefined ? (data.customerId || null) : undefined,
       },

--- a/src/features/vehicles/Components/VehicleForm.tsx
+++ b/src/features/vehicles/Components/VehicleForm.tsx
@@ -57,6 +57,7 @@ interface VehicleFormProps {
     fuelType?: string | null;
     transmission?: string | null;
     engineSize?: string | null;
+    engineCode?: string | null;
     imageUrl?: string | null;
     customerId?: string | null;
   };
@@ -160,6 +161,7 @@ export function VehicleForm({ open, onOpenChange, vehicle, customers }: VehicleF
         fuelType: (formData.get("fuelType") as string) || undefined,
         transmission: (formData.get("transmission") as string) || undefined,
         engineSize: (formData.get("engineSize") as string) || undefined,
+        engineCode: (formData.get("engineCode") as string) || undefined,
         customerId: selectedCustomerId === "none" ? undefined : selectedCustomerId || undefined,
       };
 
@@ -435,14 +437,25 @@ export function VehicleForm({ open, onOpenChange, vehicle, customers }: VehicleF
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="engineSize">{isMarine ? t("engineSizeMarine") : t("engineSize")}</Label>
-            <Input
-              id="engineSize"
-              name="engineSize"
-              placeholder={isMarine ? "Mercury F 350 XXL Verado V-10 (350 hp)" : "2.5L"}
-              defaultValue={vehicle?.engineSize ?? ""}
-            />
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="engineSize">{isMarine ? t("engineSizeMarine") : t("engineSize")}</Label>
+              <Input
+                id="engineSize"
+                name="engineSize"
+                placeholder={isMarine ? "Mercury F 350 XXL Verado V-10 (350 hp)" : "2.5L"}
+                defaultValue={vehicle?.engineSize ?? ""}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="engineCode">{t("engineCode")}</Label>
+              <Input
+                id="engineCode"
+                name="engineCode"
+                placeholder="2AR-FE"
+                defaultValue={vehicle?.engineCode ?? ""}
+              />
+            </div>
           </div>
 
           <div className="flex justify-end gap-3 pt-4">

--- a/src/features/vehicles/Components/VehicleForm.tsx
+++ b/src/features/vehicles/Components/VehicleForm.tsx
@@ -29,6 +29,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -192,6 +193,9 @@ export function VehicleForm({ open, onOpenChange, vehicle, customers }: VehicleF
           <DialogTitle>
             {vehicle ? t("editTitle") : t("addTitle")}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            {vehicle ? t("editTitle") : t("addTitle")}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/features/vehicles/Schema/vehicleSchema.ts
+++ b/src/features/vehicles/Schema/vehicleSchema.ts
@@ -14,6 +14,7 @@ export const createVehicleSchema = z.object({
   fuelType: z.string().optional(),
   transmission: z.string().optional(),
   engineSize: z.string().optional(),
+  engineCode: z.string().optional(),
   purchaseDate: z.string().optional(),
   purchasePrice: z.coerce.number().optional(),
   imageUrl: z.string().optional(),


### PR DESCRIPTION
- Add optional `engineCode` field to the `Vehicle` model (Prisma schema + migration)
- Surface `engineCode` end-to-end: Zod schema, server action, Edit Vehicle modal input, and vehicle detail header (rendered inline next to license plate / VIN)
- Add `engineCode` translation key across all 12 locales