### PR TITLE
Remove internal service notes to customer-facing invoices

### DIFF
--- a/src/app/(public)/share/invoice/[orgId]/[token]/invoice-view.tsx
+++ b/src/app/(public)/share/invoice/[orgId]/[token]/invoice-view.tsx
@@ -139,7 +139,7 @@ function isFieldVisible(config: InvoiceLayoutConfig | undefined, sectionId: stri
 }
 
 function getSectionOrder(config: InvoiceLayoutConfig | undefined): string[] {
-  if (!config) return ['header', 'customer', 'vehicle', 'service', 'parts_table', 'labor_table', 'findings', 'totals', 'general', 'notes', 'diagnostic_notes', 'bank_account', 'footer']
+  if (!config) return ['header', 'customer', 'vehicle', 'service', 'parts_table', 'labor_table', 'findings', 'totals', 'general', 'notes', 'bank_account', 'footer']
   return [...config.sections].sort((a, b) => a.order - b.order).map(s => s.id)
 }
 
@@ -1017,18 +1017,6 @@ export function InvoiceView({
                   <div
                     className="notes-content text-sm text-gray-600 dark:text-gray-400"
                     dangerouslySetInnerHTML={{ __html: sanitizeHtml(record.invoiceNotes!) }}
-                  />
-                </div>
-              )
-
-            case 'diagnostic_notes':
-              if (!hasContent(record.diagnosticNotes)) return null
-              return (
-                <div key="diagnostic_notes" className="mt-4 rounded-lg bg-gray-50 p-4 dark:bg-gray-800">
-                  <p className="mb-1 text-xs font-bold uppercase" style={{ color: primaryColor }}>{t('diagnosticNotes')}</p>
-                  <div
-                    className="notes-content text-sm text-gray-600 dark:text-gray-400"
-                    dangerouslySetInnerHTML={{ __html: sanitizeHtml(record.diagnosticNotes!) }}
                   />
                 </div>
               )

--- a/src/app/(public)/share/quote/[orgId]/[token]/quote-view.tsx
+++ b/src/app/(public)/share/quote/[orgId]/[token]/quote-view.tsx
@@ -82,7 +82,7 @@ function isSectionVisible(config: InvoiceLayoutConfig | undefined, sectionId: st
 }
 
 function getSectionOrder(config: InvoiceLayoutConfig | undefined): string[] {
-  if (!config) return ['header', 'customer', 'vehicle', 'service', 'parts_table', 'labor_table', 'totals', 'general', 'notes', 'diagnostic_notes', 'bank_account', 'footer'];
+  if (!config) return ['header', 'customer', 'vehicle', 'service', 'parts_table', 'labor_table', 'totals', 'general', 'notes', 'bank_account', 'footer'];
   return [...config.sections].sort((a, b) => a.order - b.order).map(s => s.id);
 }
 

--- a/src/features/settings/Components/InvoiceLayoutPreviewRenderer.tsx
+++ b/src/features/settings/Components/InvoiceLayoutPreviewRenderer.tsx
@@ -44,8 +44,7 @@ const DUMMY_INVOICE_DATA = {
   shopName: "Your Workshop",
   techName: "Mike Johnson",
   mileage: 45230,
-  diagnosticNotes:
-    "<p>Brake wear at 15%. Recommended replacement within 5,000 miles.</p>",
+  diagnosticNotes: null,
   findings: [
     { description: "Rear brake pads worn to 15%", severity: "needs_work", notes: "Recommend replacement within 5,000 miles" },
     { description: "Minor oil leak at valve cover gasket", severity: "monitor", notes: null },

--- a/src/features/settings/Schema/invoiceLayoutSchema.ts
+++ b/src/features/settings/Schema/invoiceLayoutSchema.ts
@@ -64,7 +64,6 @@ export const BUILTIN_SECTIONS = [
   { id: "totals", name: "Totals" },
   { id: "notes", name: "Notes" },
   { id: "warranty", name: "Warranty" },
-  { id: "diagnostic_notes", name: "Diagnostic Notes" },
   { id: "bank_account", name: "Bank Account" },
   { id: "footer", name: "Footer" },
   { id: "telegram_qr", name: "Telegram QR" },
@@ -139,7 +138,6 @@ export const COLUMN_ELIGIBLE_SECTIONS = new Set<string>([
   "service",
   "general",
   "notes",
-  "diagnostic_notes",
   "bank_account",
 ]);
 

--- a/src/features/vehicles/Components/invoice-pdf/InvoicePDF.tsx
+++ b/src/features/vehicles/Components/invoice-pdf/InvoicePDF.tsx
@@ -7,7 +7,7 @@ import { Header } from './Header'
 import { CustomerSection, VehicleSection, ServiceSection } from './InfoSection'
 import { PartsTable, LaborTable, FindingsPdfSection } from './Tables'
 import { Totals } from './Totals'
-import { NotesOnly, BankAccountSection, DiagnosticNotesSection } from './Notes'
+import { NotesOnly, BankAccountSection } from './Notes'
 import { WarrantySection } from './Warranty'
 import { CustomFields } from './CustomFields'
 import { Footer, AttachmentsFooter } from './Footer'
@@ -273,15 +273,6 @@ export function InvoicePDF({
         labels={labels}
         dateFormat={invoiceSettings?.dateFormat}
         timezone={invoiceSettings?.timezone}
-      />
-    ),
-
-    diagnostic_notes: (
-      <DiagnosticNotesSection
-        diagnosticNotes={data.diagnosticNotes}
-        fontFamily={fontFamily}
-        styles={styles}
-        labels={labels}
       />
     ),
 

--- a/src/features/vehicles/Components/invoice-pdf/Notes.tsx
+++ b/src/features/vehicles/Components/invoice-pdf/Notes.tsx
@@ -12,17 +12,6 @@ function fillTemplate(template: string, values: Record<string, string>): string 
   )
 }
 
-interface NotesProps {
-  invoiceNotes: string | null
-  diagnosticNotes: string | null
-  invoiceSettings?: InvoiceSettingsProps
-  otherAttachments: OtherAttachment[]
-  pdfAttachmentNames: string[]
-  fontFamily: string
-  styles: Record<string, Style>
-  labels: Record<string, string>
-}
-
 // Simple HTML token types
 type Token =
   | { type: 'open'; tag: string }
@@ -336,64 +325,3 @@ export function BankAccountSection({
   )
 }
 
-export function DiagnosticNotesSection({
-  diagnosticNotes,
-  fontFamily,
-  styles,
-  labels,
-}: {
-  diagnosticNotes: string | null
-  fontFamily: string
-  styles: Record<string, Style>
-  labels: Record<string, string>
-}) {
-  const fontBold = getFontBold(fontFamily)
-  if (!hasContent(diagnosticNotes)) return null
-  return (
-    <View wrap={false} style={{ ...styles.notesSection, marginTop: 8 }}>
-      <Text style={styles.notesLabel}>{labels.diagnosticNotes || 'Diagnostic Notes'}</Text>
-      <HtmlToPdf html={diagnosticNotes!} baseStyle={styles.notesText} fontBold={fontBold} />
-    </View>
-  )
-}
-
-
-// ---------------------------------------------------------------------------
-// Composite Notes component – kept for backward compatibility
-// ---------------------------------------------------------------------------
-
-export function Notes({
-  invoiceNotes,
-  diagnosticNotes,
-  invoiceSettings,
-  otherAttachments,
-  pdfAttachmentNames,
-  fontFamily,
-  styles,
-  labels,
-}: NotesProps) {
-  return (
-    <>
-      <NotesOnly
-        invoiceNotes={invoiceNotes}
-        otherAttachments={otherAttachments}
-        pdfAttachmentNames={pdfAttachmentNames}
-        fontFamily={fontFamily}
-        styles={styles}
-        labels={labels}
-      />
-      <BankAccountSection
-        invoiceSettings={invoiceSettings}
-        fontFamily={fontFamily}
-        styles={styles}
-        labels={labels}
-      />
-      <DiagnosticNotesSection
-        diagnosticNotes={diagnosticNotes}
-        fontFamily={fontFamily}
-        styles={styles}
-        labels={labels}
-      />
-    </>
-  )
-}


### PR DESCRIPTION
The "Internal" notes tab is wired to the diagnosticNotes field, which was rendered on the invoice PDF and public share views — contradicting the UI promise "Internal notes (not shown on invoice)".