### PR TITLE
Fix inventory stock tracking on work orders

### DIFF
--- a/messages/de/service.json
+++ b/messages/de/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Barcode scannen",
     "partFound": "\"{name}\" aus dem Lager hinzugefügt",
     "partNotFound": "Kein Teil für Barcode \"{barcode}\" gefunden",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Nicht auf Lager",
+    "onBackorder": "Im Rückstand ({count})"
   },
   "labor": {
     "title": "Arbeit",

--- a/messages/en/service.json
+++ b/messages/en/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Scan Barcode",
     "partFound": "Added \"{name}\" from inventory",
     "partNotFound": "No part found for barcode \"{barcode}\"",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Out of stock",
+    "onBackorder": "On backorder ({count})"
   },
   "labor": {
     "title": "Labor & Services",

--- a/messages/es/service.json
+++ b/messages/es/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Escanear código de barras",
     "partFound": "\"{name}\" añadido del inventario",
     "partNotFound": "No se encontró pieza para el código de barras \"{barcode}\"",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Agotado",
+    "onBackorder": "En pedido pendiente ({count})"
   },
   "labor": {
     "title": "Mano de Obra",

--- a/messages/fr/service.json
+++ b/messages/fr/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Scanner le code-barres",
     "partFound": "\"{name}\" ajouté depuis l'inventaire",
     "partNotFound": "Aucune pièce trouvée pour le code-barres \"{barcode}\"",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "En rupture de stock",
+    "onBackorder": "En réapprovisionnement ({count})"
   },
   "labor": {
     "title": "Main-d'œuvre",

--- a/messages/it/service.json
+++ b/messages/it/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Scansiona codice a barre",
     "partFound": "\"{name}\" aggiunto dall'inventario",
     "partNotFound": "Nessun pezzo trovato per il codice a barre \"{barcode}\"",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Esaurito",
+    "onBackorder": "In arretrato ({count})"
   },
   "labor": {
     "title": "Manodopera",

--- a/messages/lt/service.json
+++ b/messages/lt/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Nuskaityti brūkšninį kodą",
     "partFound": "Pridėta \"{name}\" iš inventoriaus",
     "partNotFound": "Dalis brūkšniniam kodui \"{barcode}\" nerasta",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Nėra sandėlyje",
+    "onBackorder": "Užsakoma ({count})"
   },
   "labor": {
     "title": "Darbai ir paslaugos",

--- a/messages/nb/service.json
+++ b/messages/nb/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Skann strekkode",
     "partFound": "\"{name}\" lagt til fra lageret",
     "partNotFound": "Ingen del funnet for strekkode \"{barcode}\"",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Utsolgt",
+    "onBackorder": "På restordre ({count})"
   },
   "labor": {
     "title": "Arbeid",

--- a/messages/nl/service.json
+++ b/messages/nl/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Barcode scannen",
     "partFound": "\"{name}\" toegevoegd uit voorraad",
     "partNotFound": "Geen onderdeel gevonden voor barcode \"{barcode}\"",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Niet op voorraad",
+    "onBackorder": "In nabestelling ({count})"
   },
   "labor": {
     "title": "Arbeidskosten",

--- a/messages/pl/service.json
+++ b/messages/pl/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Skanuj kod kreskowy",
     "partFound": "Dodano \"{name}\" z magazynu",
     "partNotFound": "Nie znaleziono części dla kodu kreskowego \"{barcode}\"",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Brak w magazynie",
+    "onBackorder": "W zamówieniu ({count})"
   },
   "labor": {
     "title": "Praca",

--- a/messages/pt-BR/service.json
+++ b/messages/pt-BR/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Escanear código de barras",
     "partFound": "\"{name}\" adicionado do estoque",
     "partNotFound": "Nenhuma peça encontrada para o código de barras \"{barcode}\"",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Fora de estoque",
+    "onBackorder": "Sob encomenda ({count})"
   },
   "labor": {
     "title": "Mão de Obra",

--- a/messages/ru/service.json
+++ b/messages/ru/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Сканировать штрихкод",
     "partFound": "\"{name}\" добавлено из склада",
     "partNotFound": "Деталь для штрихкода \"{barcode}\" не найдена",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Нет в наличии",
+    "onBackorder": "Под заказ ({count})"
   },
   "labor": {
     "title": "Работа",

--- a/messages/tr/service.json
+++ b/messages/tr/service.json
@@ -105,7 +105,9 @@
     "scanTitle": "Barkod tara",
     "partFound": "\"{name}\" envanterden eklendi",
     "partNotFound": "\"{barcode}\" barkodu için parça bulunamadı",
-    "deleteRow": "Delete row"
+    "deleteRow": "Delete row",
+    "outOfStock": "Stokta yok",
+    "onBackorder": "Ön siparişte ({count})"
   },
   "labor": {
     "title": "İşçilik",

--- a/src/__tests__/features/inventory/reconcile-stock.test.ts
+++ b/src/__tests__/features/inventory/reconcile-stock.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for reconcileInventoryForParts — the single source of truth for how
+ * work-order parts move inventory stock.
+ *
+ * The helper must apply the NET delta between a record's previous and next
+ * linked parts: adding/increasing consumes stock, removing/reducing restocks,
+ * and unchanged quantities touch nothing. Every write is scoped to the
+ * caller's organization and applied atomically via `{ decrement }`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { reconcileInventoryForParts } from "@/features/inventory/Lib/reconcileStock";
+
+const ORG = "org-1";
+
+/** A fake transaction client that records inventoryPart.updateMany calls. */
+function makeTx() {
+  const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tx = { inventoryPart: { updateMany } } as any;
+  return { tx, updateMany };
+}
+
+/** Extract {id, decrement} pairs from recorded updateMany calls. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function movements(updateMany: any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return updateMany.mock.calls.map((c: any[]) => ({
+    id: c[0].where.id,
+    organizationId: c[0].where.organizationId,
+    decrement: c[0].data.quantity.decrement,
+  }));
+}
+
+describe("reconcileInventoryForParts", () => {
+  it("deducts stock for newly added linked parts (delta from empty)", async () => {
+    const { tx, updateMany } = makeTx();
+    await reconcileInventoryForParts(tx, ORG, [], [{ inventoryPartId: "p1", quantity: 3 }]);
+    expect(movements(updateMany)).toEqual([{ id: "p1", organizationId: ORG, decrement: 3 }]);
+  });
+
+  it("ignores free-text parts that are not linked to inventory", async () => {
+    const { tx, updateMany } = makeTx();
+    await reconcileInventoryForParts(tx, ORG, [], [
+      { inventoryPartId: null, quantity: 5 },
+      { quantity: 2 },
+    ]);
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+
+  it("restocks fully when a part is removed (delete work order)", async () => {
+    const { tx, updateMany } = makeTx();
+    await reconcileInventoryForParts(tx, ORG, [{ inventoryPartId: "p1", quantity: 4 }], []);
+    // Negative decrement = increment = restock.
+    expect(movements(updateMany)).toEqual([{ id: "p1", organizationId: ORG, decrement: -4 }]);
+  });
+
+  it("applies only the delta when a quantity increases", async () => {
+    const { tx, updateMany } = makeTx();
+    await reconcileInventoryForParts(
+      tx,
+      ORG,
+      [{ inventoryPartId: "p1", quantity: 2 }],
+      [{ inventoryPartId: "p1", quantity: 5 }],
+    );
+    expect(movements(updateMany)).toEqual([{ id: "p1", organizationId: ORG, decrement: 3 }]);
+  });
+
+  it("restocks the delta when a quantity decreases", async () => {
+    const { tx, updateMany } = makeTx();
+    await reconcileInventoryForParts(
+      tx,
+      ORG,
+      [{ inventoryPartId: "p1", quantity: 5 }],
+      [{ inventoryPartId: "p1", quantity: 2 }],
+    );
+    expect(movements(updateMany)).toEqual([{ id: "p1", organizationId: ORG, decrement: -3 }]);
+  });
+
+  it("does nothing when the linked parts are unchanged (no double-count on re-save)", async () => {
+    const { tx, updateMany } = makeTx();
+    const same = [{ inventoryPartId: "p1", quantity: 3 }];
+    await reconcileInventoryForParts(tx, ORG, same, [...same]);
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+
+  it("aggregates multiple lines that reference the same inventory part", async () => {
+    const { tx, updateMany } = makeTx();
+    await reconcileInventoryForParts(tx, ORG, [], [
+      { inventoryPartId: "p1", quantity: 2 },
+      { inventoryPartId: "p1", quantity: 3 },
+    ]);
+    expect(movements(updateMany)).toEqual([{ id: "p1", organizationId: ORG, decrement: 5 }]);
+  });
+
+  it("handles several different parts changing at once", async () => {
+    const { tx, updateMany } = makeTx();
+    await reconcileInventoryForParts(
+      tx,
+      ORG,
+      [
+        { inventoryPartId: "p1", quantity: 2 },
+        { inventoryPartId: "p2", quantity: 1 },
+      ],
+      [
+        { inventoryPartId: "p1", quantity: 2 }, // unchanged -> skipped
+        { inventoryPartId: "p3", quantity: 4 }, // new -> deduct 4
+        // p2 removed -> restock 1
+      ],
+    );
+    const moves = movements(updateMany);
+    expect(moves).toContainEqual({ id: "p2", organizationId: ORG, decrement: -1 });
+    expect(moves).toContainEqual({ id: "p3", organizationId: ORG, decrement: 4 });
+    expect(moves.find((m: { id: string }) => m.id === "p1")).toBeUndefined();
+    expect(moves).toHaveLength(2);
+  });
+
+  it("rounds fractional quantities to whole stock units", async () => {
+    const { tx, updateMany } = makeTx();
+    await reconcileInventoryForParts(tx, ORG, [], [
+      { inventoryPartId: "p1", quantity: 2.4 },
+      { inventoryPartId: "p2", quantity: 2.6 },
+    ]);
+    const moves = movements(updateMany);
+    expect(moves).toContainEqual({ id: "p1", organizationId: ORG, decrement: 2 });
+    expect(moves).toContainEqual({ id: "p2", organizationId: ORG, decrement: 3 });
+  });
+
+  it("always scopes writes to the caller's organization", async () => {
+    const { tx, updateMany } = makeTx();
+    await reconcileInventoryForParts(tx, ORG, [], [{ inventoryPartId: "p1", quantity: 1 }]);
+    expect(updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ organizationId: ORG }) }),
+    );
+  });
+});

--- a/src/__tests__/features/workorders/add-part.test.ts
+++ b/src/__tests__/features/workorders/add-part.test.ts
@@ -16,15 +16,19 @@ vi.mock("@/lib/cached-session", () => ({
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
-vi.mock("@/lib/db", () => ({
-  db: {
+vi.mock("@/lib/db", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const db: any = {
     user: { findUnique: vi.fn() },
     serviceRecord: { findFirst: vi.fn(), update: vi.fn() },
     servicePart: { create: vi.fn(), aggregate: vi.fn() },
     serviceLabor: { aggregate: vi.fn() },
-    inventoryPart: { update: vi.fn() },
-  },
-}));
+    inventoryPart: { update: vi.fn(), updateMany: vi.fn() },
+  };
+  // Run the transaction callback against the same mock db (tx === db).
+  db.$transaction = vi.fn(async (cb: any) => cb(db));
+  return { db };
+});
 
 import { getCachedSession, getCachedMembership } from "@/lib/cached-session";
 import { db } from "@/lib/db";
@@ -51,6 +55,10 @@ function setupAuth() {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // resetAllMocks clears implementations, so restore the transaction runner
+  // (invoke the callback with the mock db as the transaction client).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.mocked(db.$transaction).mockImplementation(async (cb: any) => cb(db));
 });
 
 describe("addPartToServiceRecord — totals recalculation", () => {

--- a/src/__tests__/features/workorders/create-workorder.test.ts
+++ b/src/__tests__/features/workorders/create-workorder.test.ts
@@ -257,14 +257,14 @@ describe("createServiceRecord — parts and inventory", () => {
 
     const mockCreate = vi.fn().mockResolvedValue({ id: "sr-inv" });
     const mockInvFind = vi.fn().mockResolvedValue({ id: "inv-1", quantity: 10, organizationId: ORG });
-    const mockInvUpdate = vi.fn();
+    const mockInvUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
     vi.mocked(db.$transaction).mockImplementation(async (fn: any) =>
       fn({
         serviceRecord: { create: mockCreate },
         servicePart: { createMany: vi.fn() },
         serviceLabor: { createMany: vi.fn() },
         serviceAttachment: { createMany: vi.fn() },
-        inventoryPart: { findFirst: mockInvFind, update: mockInvUpdate },
+        inventoryPart: { findFirst: mockInvFind, updateMany: mockInvUpdateMany },
       })
     );
 
@@ -280,28 +280,29 @@ describe("createServiceRecord — parts and inventory", () => {
       totalAmount: 15,
     });
 
-    expect(mockInvUpdate).toHaveBeenCalledWith(
+    // Stock is deducted atomically and scoped to the org.
+    expect(mockInvUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "inv-1" },
-        data: { quantity: 9 }, // 10 - 1
+        where: { id: "inv-1", organizationId: ORG },
+        data: { quantity: { decrement: 1 } },
       })
     );
   });
 
-  it("does not allow negative inventory (floors at 0)", async () => {
+  it("allows stock to go negative when consuming more than on hand (reversible over-consumption)", async () => {
     setupAuth();
     setupCommonMocks();
 
     const mockCreate = vi.fn().mockResolvedValue({ id: "sr-neg" });
     const mockInvFind = vi.fn().mockResolvedValue({ id: "inv-2", quantity: 1, organizationId: ORG });
-    const mockInvUpdate = vi.fn();
+    const mockInvUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
     vi.mocked(db.$transaction).mockImplementation(async (fn: any) =>
       fn({
         serviceRecord: { create: mockCreate },
         servicePart: { createMany: vi.fn() },
         serviceLabor: { createMany: vi.fn() },
         serviceAttachment: { createMany: vi.fn() },
-        inventoryPart: { findFirst: mockInvFind, update: mockInvUpdate },
+        inventoryPart: { findFirst: mockInvFind, updateMany: mockInvUpdateMany },
       })
     );
 
@@ -317,9 +318,12 @@ describe("createServiceRecord — parts and inventory", () => {
       totalAmount: 500,
     });
 
-    expect(mockInvUpdate).toHaveBeenCalledWith(
+    // Decrement the full 5 (1 on hand -> -4). Clamping at 0 would corrupt the
+    // count once the record is later edited or deleted, so the true signed
+    // value is kept.
+    expect(mockInvUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: { quantity: 0 },
+        data: { quantity: { decrement: 5 } },
       })
     );
   });

--- a/src/__tests__/multitenancy/vehicle-service-isolation.test.ts
+++ b/src/__tests__/multitenancy/vehicle-service-isolation.test.ts
@@ -38,6 +38,9 @@ vi.mock("@/lib/db", () => ({
       findFirst: vi.fn(),
       delete: vi.fn(),
     },
+    servicePart: { findMany: vi.fn() },
+    inventoryPart: { updateMany: vi.fn() },
+    $transaction: vi.fn(),
   },
 }));
 
@@ -91,6 +94,11 @@ const ORG_A_VEHICLE = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // deleteServiceRecord restocks inventory inside a transaction; run the
+  // callback against the mock db and default to a record with no parts.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.mocked(db.$transaction).mockImplementation(async (cb: any) => cb(db));
+  vi.mocked(db.servicePart.findMany).mockResolvedValue([] as any);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/app/(authenticated)/vehicles/[id]/service/[serviceId]/page.tsx
+++ b/src/app/(authenticated)/vehicles/[id]/service/[serviceId]/page.tsx
@@ -162,6 +162,10 @@ export default async function ServiceDetailPage({
       total: p.total,
       unitCost: p.unitCost ?? 0,
       markupPercent: p.markupPercent ?? 0,
+      // Preserve the inventory link so editing/saving a work order keeps
+      // deducting the right stock. Without this, a saved edit sends unlinked
+      // parts and inventory reconciliation restocks the "removed" part.
+      inventoryPartId: p.inventoryPartId ?? undefined,
     })),
     laborItems: record.laborItems.map((l) => ({
       description: l.description,

--- a/src/features/inventory/Actions/inventoryActions.ts
+++ b/src/features/inventory/Actions/inventoryActions.ts
@@ -302,8 +302,11 @@ export async function getInventoryCategories() {
 
 export async function getInventoryPartsList() {
   return withAuth(async ({ userId, organizationId }) => {
+    // Include out-of-stock and backordered (negative) parts too — the picker
+    // shows their stock state so a part can still be added to a work order
+    // when depleted (which then correctly drives stock negative / backorder).
     return db.inventoryPart.findMany({
-      where: { organizationId, isArchived: false, quantity: { gt: 0 } },
+      where: { organizationId, isArchived: false },
       select: {
         id: true,
         partNumber: true,

--- a/src/features/inventory/Lib/reconcileStock.ts
+++ b/src/features/inventory/Lib/reconcileStock.ts
@@ -1,0 +1,80 @@
+import type { Prisma } from "@/generated/prisma/client";
+
+/**
+ * A part line that may be linked to an inventory item. Only lines with a
+ * non-null `inventoryPartId` move stock; free-text parts are ignored.
+ */
+export interface StockPartLine {
+  inventoryPartId?: string | null;
+  quantity: number;
+}
+
+/**
+ * Convert a (possibly fractional) part quantity into whole stock units.
+ *
+ * `InventoryPart.quantity` is an integer column while `ServicePart.quantity`
+ * is a float, so we round to the nearest whole unit. Rounding is applied
+ * identically to the previous and next sets, so any delta stays internally
+ * consistent across create / edit / delete.
+ */
+function stockUnits(quantity: number): number {
+  if (!Number.isFinite(quantity) || quantity <= 0) return 0;
+  return Math.round(quantity);
+}
+
+/**
+ * Apply the net inventory movement for a service record whose linked parts
+ * change from `previous` to `next`.
+ *
+ * Semantics:
+ *   - A part present in `next` but not `previous` (or with a larger quantity)
+ *     consumes stock → decrement.
+ *   - A part removed or reduced restocks → increment.
+ *   - Unchanged quantities produce a zero delta and touch nothing.
+ *
+ * The movement is computed per `inventoryPartId` as the sum of `next`
+ * quantities minus the sum of `previous` quantities, then applied with a
+ * single atomic `{ decrement }` per part (a negative delta increments, i.e.
+ * restocks). Because it is atomic and never reads-then-writes, concurrent
+ * deploys/requests cannot lose updates.
+ *
+ * Every write is scoped to `organizationId`, so a stale or cross-organization
+ * `inventoryPartId` simply matches no rows and is skipped — it can never
+ * mutate another tenant's inventory.
+ *
+ * Stock is allowed to go negative: over-consuming is real information
+ * ("you used more than you had on hand") and, crucially, keeps the operation
+ * reversible. Clamping at zero would corrupt the count as soon as the part is
+ * later removed or the record deleted.
+ *
+ * MUST be called inside a transaction so the stock movement commits or rolls
+ * back together with the ServicePart changes that caused it.
+ */
+export async function reconcileInventoryForParts(
+  tx: Prisma.TransactionClient,
+  organizationId: string,
+  previous: readonly StockPartLine[],
+  next: readonly StockPartLine[],
+): Promise<void> {
+  // inventoryPartId -> net units to DECREMENT (negative = restock)
+  const netDecrement = new Map<string, number>();
+
+  for (const line of previous) {
+    if (!line.inventoryPartId) continue;
+    const current = netDecrement.get(line.inventoryPartId) ?? 0;
+    netDecrement.set(line.inventoryPartId, current - stockUnits(line.quantity));
+  }
+  for (const line of next) {
+    if (!line.inventoryPartId) continue;
+    const current = netDecrement.get(line.inventoryPartId) ?? 0;
+    netDecrement.set(line.inventoryPartId, current + stockUnits(line.quantity));
+  }
+
+  for (const [inventoryPartId, delta] of netDecrement) {
+    if (delta === 0) continue;
+    await tx.inventoryPart.updateMany({
+      where: { id: inventoryPartId, organizationId },
+      data: { quantity: { decrement: delta } },
+    });
+  }
+}

--- a/src/features/vehicles/Actions/addPartToServiceRecord.ts
+++ b/src/features/vehicles/Actions/addPartToServiceRecord.ts
@@ -5,6 +5,7 @@ import { withAuth } from "@/lib/with-auth";
 import { PermissionAction, PermissionSubject } from "@/lib/permissions";
 import { revalidatePath } from "next/cache";
 import { calculateTotals } from "@/lib/tax";
+import { reconcileInventoryForParts } from "@/features/inventory/Lib/reconcileStock";
 
 export async function addPartToServiceRecord(input: {
   serviceRecordId: string;
@@ -24,58 +25,60 @@ export async function addPartToServiceRecord(input: {
       });
       if (!record) throw new Error("Service record not found");
 
-      const part = await db.servicePart.create({
-        data: {
-          partNumber: input.partNumber || null,
-          name: input.name,
-          quantity: input.quantity,
-          unitPrice: input.unitPrice,
-          total: input.total,
-          unitCost: input.unitCost,
-          inventoryPartId: input.inventoryPartId || null,
-          serviceRecordId: record.id,
-        },
-      });
-
-      // Recalculate totals
-      const [partsAgg, laborAgg] = await Promise.all([
-        db.servicePart.aggregate({
-          where: { serviceRecordId: record.id },
-          _sum: { total: true },
-        }),
-        db.serviceLabor.aggregate({
-          where: { serviceRecordId: record.id },
-          _sum: { total: true },
-        }),
-      ]);
-
-      const subtotal = (partsAgg._sum.total || 0) + (laborAgg._sum.total || 0);
-      const discountAmount =
-        record.discountType === "percentage"
-          ? subtotal * ((record.discountValue ?? 0) / 100)
-          : record.discountType === "fixed"
-            ? Math.min(record.discountValue ?? 0, subtotal)
-            : 0;
-      const { taxAmount, totalAmount } = calculateTotals({
-        subtotal,
-        discountAmount,
-        taxRate: record.taxRate,
-        taxInclusive: record.taxInclusive,
-      });
-
-      await db.serviceRecord.update({
-        where: { id: record.id },
-        data: { subtotal, taxAmount, totalAmount },
-      });
-
-      // Deduct inventory stock if linked
-      if (input.inventoryPartId) {
-        const invResult = await db.inventoryPart.updateMany({
-          where: { id: input.inventoryPartId, organizationId },
-          data: { quantity: { decrement: input.quantity } },
+      // Create the part, recalculate totals and deduct inventory stock in one
+      // transaction so the line and its stock movement commit together.
+      const part = await db.$transaction(async (tx) => {
+        const created = await tx.servicePart.create({
+          data: {
+            partNumber: input.partNumber || null,
+            name: input.name,
+            quantity: input.quantity,
+            unitPrice: input.unitPrice,
+            total: input.total,
+            unitCost: input.unitCost,
+            inventoryPartId: input.inventoryPartId || null,
+            serviceRecordId: record.id,
+          },
         });
-        if (invResult.count === 0) throw new Error("Inventory part not found");
-      }
+
+        // Recalculate totals
+        const [partsAgg, laborAgg] = await Promise.all([
+          tx.servicePart.aggregate({
+            where: { serviceRecordId: record.id },
+            _sum: { total: true },
+          }),
+          tx.serviceLabor.aggregate({
+            where: { serviceRecordId: record.id },
+            _sum: { total: true },
+          }),
+        ]);
+
+        const subtotal = (partsAgg._sum.total || 0) + (laborAgg._sum.total || 0);
+        const discountAmount =
+          record.discountType === "percentage"
+            ? subtotal * ((record.discountValue ?? 0) / 100)
+            : record.discountType === "fixed"
+              ? Math.min(record.discountValue ?? 0, subtotal)
+              : 0;
+        const { taxAmount, totalAmount } = calculateTotals({
+          subtotal,
+          discountAmount,
+          taxRate: record.taxRate,
+          taxInclusive: record.taxInclusive,
+        });
+
+        await tx.serviceRecord.update({
+          where: { id: record.id },
+          data: { subtotal, taxAmount, totalAmount },
+        });
+
+        // Deduct inventory stock for the newly added line (delta from empty).
+        await reconcileInventoryForParts(tx, organizationId, [], [
+          { inventoryPartId: input.inventoryPartId, quantity: input.quantity },
+        ]);
+
+        return created;
+      });
 
       revalidatePath(`/vehicles/${record.vehicleId}/service/${record.id}`);
 

--- a/src/features/vehicles/Actions/serviceActions.ts
+++ b/src/features/vehicles/Actions/serviceActions.ts
@@ -10,6 +10,7 @@ import { resolveUploadPath } from "@/lib/resolve-upload-path";
 import { resolveInvoicePrefix } from "@/lib/invoice-utils";
 import { notificationBus } from "@/lib/notification-bus";
 import { PermissionAction, PermissionSubject } from "@/lib/permissions";
+import { reconcileInventoryForParts } from "@/features/inventory/Lib/reconcileStock";
 
 export async function getServiceRecords(vehicleId: string) {
   return withAuth(async ({ organizationId }) => {
@@ -300,7 +301,8 @@ export async function createServiceRecord(input: unknown) {
       });
 
       if (partItems && partItems.length > 0) {
-        // Enrich parts with unitCost from inventory and deduct stock
+        // Enrich parts with unitCost from inventory (stock movement is handled
+        // by reconcileInventoryForParts below).
         const enrichedParts = [];
         for (const p of partItems) {
           let resolvedUnitCost = p.unitCost ?? 0;
@@ -310,11 +312,6 @@ export async function createServiceRecord(input: unknown) {
             });
             if (invPart) {
               resolvedUnitCost = invPart.unitCost ?? resolvedUnitCost;
-              const newQty = invPart.quantity - Math.ceil(p.quantity);
-              await tx.inventoryPart.update({
-                where: { id: p.inventoryPartId },
-                data: { quantity: Math.max(0, newQty) },
-              });
             }
           }
           enrichedParts.push({
@@ -331,6 +328,9 @@ export async function createServiceRecord(input: unknown) {
         }
 
         await tx.servicePart.createMany({ data: enrichedParts });
+
+        // Deduct stock for inventory-linked parts (delta from an empty set).
+        await reconcileInventoryForParts(tx, organizationId, [], partItems);
       }
 
       if (laborItems && laborItems.length > 0) {
@@ -449,6 +449,15 @@ export async function updateServiceRecord(input: unknown) {
 
       // Replace parts if provided
       if (partItems !== undefined) {
+        // Snapshot the parts being replaced BEFORE deleting them, so inventory
+        // can be reconciled by the delta between the old and new linked parts
+        // (this is what keeps stock correct when parts are added, edited,
+        // reduced or removed on an existing work order).
+        const previousParts = await tx.servicePart.findMany({
+          where: { serviceRecordId: id },
+          select: { inventoryPartId: true, quantity: true },
+        });
+
         await tx.servicePart.deleteMany({ where: { serviceRecordId: id } });
         if (partItems.length > 0) {
           await tx.servicePart.createMany({
@@ -465,6 +474,8 @@ export async function updateServiceRecord(input: unknown) {
             })),
           });
         }
+
+        await reconcileInventoryForParts(tx, organizationId, previousParts, partItems);
       }
 
       // Replace labor if provided
@@ -728,7 +739,18 @@ export async function deleteServiceRecord(recordId: string) {
       }
     }
 
-    await db.serviceRecord.delete({ where: { id: recordId } });
+    // Restock any inventory-linked parts, then delete the record (its parts
+    // cascade-delete). Both happen in one transaction so stock is only
+    // returned if the delete actually commits.
+    await db.$transaction(async (tx) => {
+      const parts = await tx.servicePart.findMany({
+        where: { serviceRecordId: recordId },
+        select: { inventoryPartId: true, quantity: true },
+      });
+      await reconcileInventoryForParts(tx, organizationId, parts, []);
+      await tx.serviceRecord.delete({ where: { id: recordId } });
+    });
+
     revalidatePath("/");
     revalidatePath(`/vehicles/${record.vehicleId}`);
     revalidatePath("/services");

--- a/src/features/vehicles/Components/service-edit/InventoryPickerDialog.tsx
+++ b/src/features/vehicles/Components/service-edit/InventoryPickerDialog.tsx
@@ -151,7 +151,17 @@ export function InventoryPickerDialog({
                 ) : (
                   <span>{formatCurrency(ip.unitCost, currencyCode)}</span>
                 )}
-                <span>{t('inStock', { quantity: ip.quantity })}</span>
+                {ip.quantity > 0 ? (
+                  <span>{t('inStock', { quantity: ip.quantity })}</span>
+                ) : ip.quantity === 0 ? (
+                  <span className="font-medium text-amber-600 dark:text-amber-500">
+                    {t('outOfStock')}
+                  </span>
+                ) : (
+                  <span className="font-medium text-red-600 dark:text-red-500">
+                    {t('onBackorder', { count: Math.abs(ip.quantity) })}
+                  </span>
+                )}
               </div>
             </button>
           ))}


### PR DESCRIPTION
Deduct/restock inventory via a single atomic delta helper across create/edit/quick-add/delete, and preserve the inventory link when editing a work order (fixes stock resetting on save).
Show out-of-stock and backordered parts in the picker, flagged by state, instead of hiding them.