### PR TITLE
Fix path traversal in backup importers and Stripe webhook signature bypass

### DIFF
--- a/src/__tests__/lib/importer-path-safety.test.ts
+++ b/src/__tests__/lib/importer-path-safety.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression + security proof for the backup importers' path handling.
+ *
+ * These tests replicate the EXACT filesystem path operations.
+ *   1. legitimate backup files still resolve, read, and extract as before, and
+ *   2. path-traversal / zip-slip inputs are now blocked.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm, stat } from 'fs/promises'
+import { readFileSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import JSZip from 'jszip'
+import { resolveWithinDir } from '@/lib/safe-path'
+
+let sandbox: string
+
+beforeEach(async () => {
+  sandbox = await mkdtemp(path.join(os.tmpdir(), 'importer-test-'))
+})
+
+afterEach(async () => {
+  await rm(sandbox, { recursive: true, force: true })
+})
+
+// ── LubeLog copyFile: exact source-path resolution (strip leading slash, then
+//    resolve within backupDir) ──────────────────────────────────────────────
+function resolveLubelogSource(backupDir: string, sourcePath: string): string | null {
+  const normalizedSource = sourcePath.replace(/^\//, '')
+  return resolveWithinDir(backupDir, normalizedSource)
+}
+
+describe('import-lubelog copyFile source path', () => {
+  it('reads a legitimate relative backup file', async () => {
+    const backupDir = path.join(sandbox, 'backup')
+    await mkdir(path.join(backupDir, 'images'), { recursive: true })
+    await writeFile(path.join(backupDir, 'images', 'car.jpg'), 'REAL_IMAGE_BYTES')
+
+    const resolved = resolveLubelogSource(backupDir, 'images/car.jpg')
+    expect(resolved).not.toBeNull()
+    expect(readFileSync(resolved!).toString()).toBe('REAL_IMAGE_BYTES')
+  })
+
+  it('reads a legitimate LubeLog-style leading-slash path (no regression)', async () => {
+    const backupDir = path.join(sandbox, 'backup')
+    await mkdir(path.join(backupDir, 'images'), { recursive: true })
+    await writeFile(path.join(backupDir, 'images', 'car.jpg'), 'REAL_IMAGE_BYTES')
+
+    // LubeLog stores locations like "/images/car.jpg"; the strip must keep it working.
+    const resolved = resolveLubelogSource(backupDir, '/images/car.jpg')
+    expect(resolved).toBe(path.join(backupDir, 'images', 'car.jpg'))
+    expect(readFileSync(resolved!).toString()).toBe('REAL_IMAGE_BYTES')
+  })
+
+  it('blocks ../ traversal to a file outside the backup dir', async () => {
+    const backupDir = path.join(sandbox, 'backup')
+    await mkdir(backupDir, { recursive: true })
+    await writeFile(path.join(sandbox, 'secret.txt'), 'TOP_SECRET')
+
+    const resolved = resolveLubelogSource(backupDir, '../secret.txt')
+    expect(resolved).toBeNull() // never reaches readFileSync
+  })
+
+  it('neutralizes an absolute system path instead of reading it', async () => {
+    const backupDir = path.join(sandbox, 'backup')
+    await mkdir(backupDir, { recursive: true })
+
+    // After the leading-slash strip, "/etc/hostname" -> "etc/hostname",
+    // which resolves *inside* backupDir (a non-existent file), never /etc/hostname.
+    const resolved = resolveLubelogSource(backupDir, '/etc/hostname')
+    expect(resolved).toBe(path.join(backupDir, 'etc', 'hostname'))
+    expect(resolved!.startsWith(backupDir + path.sep)).toBe(true)
+  })
+})
+
+// ── Invoice-Ninja document read: resolve doc.url within tmpDir/documents ─────
+describe('import-invoice-ninja document path', () => {
+  it('reads a legitimate document', async () => {
+    const tmpDir = path.join(sandbox, 'in-import')
+    await mkdir(path.join(tmpDir, 'documents'), { recursive: true })
+    await writeFile(path.join(tmpDir, 'documents', 'abc.pdf'), 'PDF_BYTES')
+
+    const resolved = resolveWithinDir(path.join(tmpDir, 'documents'), 'abc.pdf')
+    expect(resolved).not.toBeNull()
+    expect(readFileSync(resolved!).toString()).toBe('PDF_BYTES')
+  })
+
+  it('blocks ../ traversal out of the documents dir', async () => {
+    const tmpDir = path.join(sandbox, 'in-import')
+    await mkdir(path.join(tmpDir, 'documents'), { recursive: true })
+    await writeFile(path.join(sandbox, 'secret.txt'), 'TOP_SECRET')
+
+    const resolved = resolveWithinDir(path.join(tmpDir, 'documents'), '../../secret.txt')
+    expect(resolved).toBeNull()
+  })
+})
+
+// ── Zip-slip extraction: real JSZip archive through the guard ────────────────
+describe('zip extraction guard (finding 1)', () => {
+  async function extractGuarded(zip: JSZip, tmpDir: string) {
+    const written: string[] = []
+    const skipped: string[] = []
+    for (const [relativePath, entry] of Object.entries(zip.files)) {
+      if (entry.dir) continue
+      const targetPath = resolveWithinDir(tmpDir, relativePath)
+      if (!targetPath) {
+        skipped.push(relativePath)
+        continue
+      }
+      await mkdir(path.dirname(targetPath), { recursive: true })
+      await writeFile(targetPath, await entry.async('nodebuffer'))
+      written.push(targetPath)
+    }
+    return { written, skipped }
+  }
+
+  it('extracts legitimate entries and skips a zip-slip entry', async () => {
+    const tmpDir = path.join(sandbox, 'extract')
+    await mkdir(tmpDir, { recursive: true })
+
+    const zip = new JSZip()
+    zip.file('lubelog_db_backup/data/cartracker.db', 'DB_BYTES')
+    zip.file('lubelog_db_backup/images/car.jpg', 'IMG_BYTES')
+    zip.file('../evil.txt', 'PWNED') // zip-slip attempt
+
+    const { written, skipped } = await extractGuarded(zip, tmpDir)
+
+    // Legit files landed inside tmpDir
+    expect(readFileSync(path.join(tmpDir, 'lubelog_db_backup/data/cartracker.db')).toString()).toBe(
+      'DB_BYTES'
+    )
+    expect(readFileSync(path.join(tmpDir, 'lubelog_db_backup/images/car.jpg')).toString()).toBe(
+      'IMG_BYTES'
+    )
+    expect(written).toHaveLength(2)
+
+    // The malicious entry was skipped and never written outside tmpDir
+    expect(skipped).toEqual(['../evil.txt'])
+    await expect(stat(path.join(sandbox, 'evil.txt'))).rejects.toThrow()
+  })
+})

--- a/src/__tests__/lib/safe-path.test.ts
+++ b/src/__tests__/lib/safe-path.test.ts
@@ -40,4 +40,20 @@ describe("resolveWithinDir", () => {
     // /tmp/import-123 must not accept /tmp/import-123-evil
     expect(resolveWithinDir(base, "../import-123-evil/x")).toBeNull();
   });
+
+  it("rejects an absolute input even when it lies within the base dir", () => {
+    // The contract is 'relative entries only' — absolute inputs are always null.
+    const inside = path.join(base, "x");
+    expect(resolveWithinDir(base, inside)).toBeNull();
+  });
+
+  it("does not reject everything when base is the filesystem root", () => {
+    // Guards the `base + path.sep` === "//" edge: a normal relative entry must
+    // still resolve when baseDir is the root.
+    const root = path.sep;
+    expect(resolveWithinDir(root, "srv/app/file")).toBe(path.join(root, "srv/app/file"));
+    // (Nothing can climb above the root, so a `..` there stays inside root by
+    // definition; the meaningful negative case at root is an absolute input.)
+    expect(resolveWithinDir(root, path.join(root, "etc"))).toBeNull();
+  });
 });

--- a/src/__tests__/lib/safe-path.test.ts
+++ b/src/__tests__/lib/safe-path.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import path from "path";
+import { resolveWithinDir } from "@/lib/safe-path";
+
+const base = path.join(path.sep, "tmp", "import-123");
+
+describe("resolveWithinDir", () => {
+  it("allows legitimate nested archive entries", () => {
+    expect(resolveWithinDir(base, "lubelog_db_backup_x/data/cartracker.db")).toBe(
+      path.join(base, "lubelog_db_backup_x/data/cartracker.db"),
+    );
+    expect(resolveWithinDir(base, "documents/client/file.pdf")).toBe(
+      path.join(base, "documents/client/file.pdf"),
+    );
+    expect(resolveWithinDir(base, "documents/sub/ok.png")).toBe(
+      path.join(base, "documents/sub/ok.png"),
+    );
+  });
+
+  it("allows the base directory itself", () => {
+    expect(resolveWithinDir(base, "")).toBe(base);
+    expect(resolveWithinDir(base, ".")).toBe(base);
+  });
+
+  it("rejects plain parent-directory traversal (zip-slip)", () => {
+    expect(resolveWithinDir(base, "../../../../home/sinamics/evil.js")).toBeNull();
+    expect(resolveWithinDir(base, "..")).toBeNull();
+  });
+
+  it("rejects traversal that hides behind an allowed prefix", () => {
+    // The Invoice-Ninja `startsWith("documents/")` bypass.
+    expect(resolveWithinDir(base, "documents/../../../../etc/cron.d/evil")).toBeNull();
+  });
+
+  it("rejects absolute-path entries instead of remapping them inside base", () => {
+    expect(resolveWithinDir(base, "/etc/passwd")).toBeNull();
+  });
+
+  it("does not treat a sibling directory with a shared prefix as inside", () => {
+    // /tmp/import-123 must not accept /tmp/import-123-evil
+    expect(resolveWithinDir(base, "../import-123-evil/x")).toBeNull();
+  });
+});

--- a/src/app/api/protected/backup/import-invoice-ninja/route.ts
+++ b/src/app/api/protected/backup/import-invoice-ninja/route.ts
@@ -6,6 +6,7 @@ import { mkdir, writeFile, rm } from "fs/promises";
 import path from "path";
 import os from "os";
 import JSZip from "jszip";
+import { resolveWithinDir } from "@/lib/safe-path";
 
 // Allow up to 5 minutes for large imports
 export const maxDuration = 300;
@@ -259,7 +260,13 @@ export async function POST(request: NextRequest) {
       if (entry.dir) continue;
       // Only extract document files, not the full backup
       if (!relativePath.startsWith("documents/")) continue;
-      const targetPath = path.join(tmpDir, relativePath);
+      // Guard against zip-slip: `startsWith("documents/")` alone is bypassable
+      // with `documents/../../..`, so verify the resolved path stays in tmpDir.
+      const targetPath = resolveWithinDir(tmpDir, relativePath);
+      if (!targetPath) {
+        console.warn(`[import-invoice-ninja] Skipping unsafe zip entry: ${relativePath}`);
+        continue;
+      }
       await mkdir(path.dirname(targetPath), { recursive: true });
       const content = await entry.async("nodebuffer");
       await writeFile(targetPath, content);
@@ -477,8 +484,14 @@ export async function POST(request: NextRequest) {
         // ── Copy attached documents ─────────────────────────────────
         const invoiceDocs = docsByInvoice.get(invoice.hashed_id) || [];
         for (const doc of invoiceDocs) {
-          // Try to read the file from the extracted zip
-          const docPath = path.join(tmpDir!, "documents", doc.url);
+          // Try to read the file from the extracted zip.
+          // Guard against path traversal: doc.url comes from backup.json and
+          // must not escape the extracted documents dir.
+          const docPath = resolveWithinDir(path.join(tmpDir!, "documents"), doc.url);
+          if (!docPath) {
+            console.warn(`[import-invoice-ninja] Skipping document with unsafe path: ${doc.url}`);
+            continue;
+          }
           let fileData: Buffer;
           try {
             const { readFileSync } = await import("fs");

--- a/src/app/api/protected/backup/import-lubelog/route.ts
+++ b/src/app/api/protected/backup/import-lubelog/route.ts
@@ -8,6 +8,7 @@ import path from "path";
 import os from "os";
 import { BSON } from "bson";
 import JSZip from "jszip";
+import { resolveWithinDir } from "@/lib/safe-path";
 
 // Allow up to 5 minutes for large imports
 export const maxDuration = 300;
@@ -177,7 +178,12 @@ async function extractZipToTempDir(zipBuffer: Buffer): Promise<string> {
   const zip = await JSZip.loadAsync(zipBuffer);
 
   for (const [relativePath, entry] of Object.entries(zip.files)) {
-    const targetPath = path.join(tmpDir, relativePath);
+    // Guard against zip-slip: skip any entry whose path escapes tmpDir.
+    const targetPath = resolveWithinDir(tmpDir, relativePath);
+    if (!targetPath) {
+      console.warn(`[import-lubelog] Skipping unsafe zip entry: ${relativePath}`);
+      continue;
+    }
     if (entry.dir) {
       await mkdir(targetPath, { recursive: true });
     } else {
@@ -292,7 +298,13 @@ export async function POST(request: NextRequest) {
 
       // Normalize source paths: strip leading /
       const normalizedSource = sourcePath.replace(/^\//, "");
-      const localPath = path.join(backupDir, normalizedSource);
+      // Guard against path traversal: the source comes from the backup's BSON
+      // (ImageLocation / file.Location) and must not escape the backup dir.
+      const localPath = resolveWithinDir(backupDir, normalizedSource);
+      if (!localPath) {
+        console.warn(`[import-lubelog] Skipping file with unsafe source path: ${sourcePath}`);
+        return null;
+      }
 
       let fileData: Buffer;
       try {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -8,16 +8,9 @@ export async function POST(request: Request) {
     const body = await request.text();
     const signature = request.headers.get("stripe-signature");
 
-    if (!signature) {
-      return NextResponse.json(
-        { error: "Missing stripe-signature header" },
-        { status: 400 },
-      );
-    }
-
-    // We need to determine which org this webhook belongs to.
-    // Parse the event without verification first to get orgId from metadata,
-    // then verify with the org's webhook secret.
+    // Parse the raw body without trusting it — only to discover which org this
+    // webhook targets, so we can load that org's Stripe credentials. Nothing
+    // from this unverified payload is trusted for recording a payment.
     let unverifiedEvent: Stripe.Event;
     try {
       unverifiedEvent = JSON.parse(body) as Stripe.Event;
@@ -32,36 +25,36 @@ export async function POST(request: Request) {
       return NextResponse.json({ received: true });
     }
 
-    const session = (unverifiedEvent.data as Stripe.Event.Data)
+    const unverifiedSession = (unverifiedEvent.data as Stripe.Event.Data)
       .object as Stripe.Checkout.Session;
-    const orgId = session.metadata?.orgId;
-    const serviceRecordId = session.metadata?.serviceRecordId;
+    const routingOrgId = unverifiedSession.metadata?.orgId;
+    const unverifiedSessionId = unverifiedSession.id;
 
-    if (!orgId || !serviceRecordId) {
+    if (!routingOrgId || !unverifiedSessionId) {
       return NextResponse.json(
         { error: "Missing metadata" },
         { status: 400 },
       );
     }
 
-    // Load org's webhook secret and verify
-    const webhookSecretSetting = await db.appSetting.findUnique({
-      where: {
-        organizationId_key: {
-          organizationId: orgId,
-          key: SETTING_KEYS.PAYMENT_STRIPE_WEBHOOK_SECRET,
+    const [webhookSecretSetting, secretKeySetting] = await Promise.all([
+      db.appSetting.findUnique({
+        where: {
+          organizationId_key: {
+            organizationId: routingOrgId,
+            key: SETTING_KEYS.PAYMENT_STRIPE_WEBHOOK_SECRET,
+          },
         },
-      },
-    });
-
-    const secretKeySetting = await db.appSetting.findUnique({
-      where: {
-        organizationId_key: {
-          organizationId: orgId,
-          key: SETTING_KEYS.PAYMENT_STRIPE_SECRET_KEY,
+      }),
+      db.appSetting.findUnique({
+        where: {
+          organizationId_key: {
+            organizationId: routingOrgId,
+            key: SETTING_KEYS.PAYMENT_STRIPE_SECRET_KEY,
+          },
         },
-      },
-    });
+      }),
+    ]);
 
     if (!secretKeySetting?.value) {
       return NextResponse.json(
@@ -70,11 +63,26 @@ export async function POST(request: Request) {
       );
     }
 
-    // Verify webhook signature if webhook secret is configured
+    const stripe = new Stripe(secretKeySetting.value);
+
+    // Establish an AUTHENTIC session object. Two trust paths, never the body:
+    //  - webhook secret configured → verify the signature over the raw body;
+    //  - no webhook secret → re-fetch the session straight from Stripe with the
+    //    org's secret key. A forged session id will not resolve to a paid
+    //    session in the org's own Stripe account, so forgery is closed either
+    //    way while real payments keep recording.
+    let session: Stripe.Checkout.Session;
+
     if (webhookSecretSetting?.value) {
-      const stripe = new Stripe(secretKeySetting.value);
+      if (!signature) {
+        return NextResponse.json(
+          { error: "Missing stripe-signature header" },
+          { status: 400 },
+        );
+      }
+      let event: Stripe.Event;
       try {
-        stripe.webhooks.constructEvent(
+        event = stripe.webhooks.constructEvent(
           body,
           signature,
           webhookSecretSetting.value,
@@ -85,6 +93,30 @@ export async function POST(request: Request) {
           { status: 400 },
         );
       }
+      if (event.type !== "checkout.session.completed") {
+        return NextResponse.json({ received: true });
+      }
+      session = event.data.object as Stripe.Checkout.Session;
+    } else {
+      try {
+        session = await stripe.checkout.sessions.retrieve(unverifiedSessionId);
+      } catch {
+        return NextResponse.json(
+          { error: "Unknown session" },
+          { status: 400 },
+        );
+      }
+    }
+
+    // From here on `session` is authentic; read every field from it.
+    const orgId = session.metadata?.orgId;
+    const serviceRecordId = session.metadata?.serviceRecordId;
+
+    if (!orgId || !serviceRecordId) {
+      return NextResponse.json(
+        { error: "Missing metadata" },
+        { status: 400 },
+      );
     }
 
     // Verify the session is actually paid

--- a/src/lib/safe-path.ts
+++ b/src/lib/safe-path.ts
@@ -12,9 +12,19 @@ import path from "path";
  * raw joined path.
  */
 export function resolveWithinDir(baseDir: string, relativePath: string): string | null {
+  // Callers pass archive-/backup-relative entry paths; an absolute input is
+  // never legitimate and could escape via a drive/root, so reject it outright.
+  if (path.isAbsolute(relativePath)) {
+    return null;
+  }
   const base = path.resolve(baseDir);
   const target = path.resolve(base, relativePath);
-  if (target === base || target.startsWith(base + path.sep)) {
+  // Use path.relative rather than a string prefix check so this stays correct
+  // when base is the filesystem root (where `base + sep` would be `//`) and on
+  // Windows. `target` is inside `base` iff the relative path neither climbs
+  // out ("..") nor is itself absolute.
+  const rel = path.relative(base, target);
+  if (rel === "" || (rel !== ".." && !rel.startsWith(".." + path.sep) && !path.isAbsolute(rel))) {
     return target;
   }
   return null;

--- a/src/lib/safe-path.ts
+++ b/src/lib/safe-path.ts
@@ -1,0 +1,21 @@
+import path from "path";
+
+/**
+ * Safely resolve an archive- or user-supplied relative path against a trusted
+ * base directory, guaranteeing the result cannot escape that directory.
+ *
+ * Returns the absolute resolved path when it stays inside `baseDir`, or `null`
+ * when the entry would escape it (zip-slip / path traversal). Absolute inputs
+ * and `..` sequences that climb above the base both resolve to `null`.
+ *
+ * Callers should treat `null` as "reject this entry" — never fall back to the
+ * raw joined path.
+ */
+export function resolveWithinDir(baseDir: string, relativePath: string): string | null {
+  const base = path.resolve(baseDir);
+  const target = path.resolve(base, relativePath);
+  if (target === base || target.startsWith(base + path.sep)) {
+    return target;
+  }
+  return null;
+}


### PR DESCRIPTION
Guards both backup importers against zip-slip writes and traversal reads via a shared resolveWithinDir helper; legitimate imports are unchanged.