### PR TITLE
Clean up bank account label and support multi-line payment details

### DIFF
--- a/messages/de/pdf.json
+++ b/messages/de/pdf.json
@@ -36,7 +36,7 @@
     "paidInFull": "VOLLSTÄNDIG BEZAHLT",
     "amountDue": "Fälliger Betrag",
     "notes": "Hinweise",
-    "bankAccount": "Til Konto / Bankkonto",
+    "bankAccount": "Bankkonto",
     "paymentInformation": "Zahlungsinformationen",
     "orgNumberLabel": "Org.-Nr.",
     "paymentTermsLabel": "Zahlungsbedingungen",

--- a/messages/de/settings.json
+++ b/messages/de/settings.json
@@ -564,7 +564,7 @@
     "readMore": "Mehr erfahren",
     "detailsTitle": "Zahlungsdetails",
     "detailsDescription": "Bankkonto und Zahlungsbedingungen auf Rechnungen.",
-    "bankAccount": "Bankkonto (IBAN / Til Konto)",
+    "bankAccount": "Bankkonto (IBAN)",
     "bankAccountPlaceholder": "NO93 8601 1117 947",
     "bankAccountHint": "Ihre Bankkontonummer oder IBAN fur den Zahlungsempfang",
     "paymentTerms": "Zahlungsbedingungen",

--- a/messages/en/pdf.json
+++ b/messages/en/pdf.json
@@ -37,7 +37,7 @@
     "paidInFull": "PAID IN FULL",
     "amountDue": "Amount Due",
     "notes": "Notes",
-    "bankAccount": "Til Konto / Bank Account",
+    "bankAccount": "Bank Account",
     "paymentInformation": "Payment Information",
     "orgNumberLabel": "Org. Number",
     "paymentTermsLabel": "Payment Terms",

--- a/messages/en/settings.json
+++ b/messages/en/settings.json
@@ -564,7 +564,7 @@
     "readMore": "Read More",
     "detailsTitle": "Payment Details",
     "detailsDescription": "Bank account and payment terms shown on invoices.",
-    "bankAccount": "Bank Account (IBAN / Til Konto)",
+    "bankAccount": "Bank Account (IBAN)",
     "bankAccountPlaceholder": "NO93 8601 1117 947",
     "bankAccountHint": "Your bank account number or IBAN for receiving payments",
     "paymentTerms": "Payment Terms",

--- a/messages/es/pdf.json
+++ b/messages/es/pdf.json
@@ -36,7 +36,7 @@
     "paidInFull": "PAGADO EN SU TOTALIDAD",
     "amountDue": "Monto adeudado",
     "notes": "Notas",
-    "bankAccount": "Til Konto / Cuenta bancaria",
+    "bankAccount": "Cuenta bancaria",
     "paymentInformation": "Información de pago",
     "orgNumberLabel": "Núm. de org.",
     "paymentTermsLabel": "Condiciones de pago",

--- a/messages/es/settings.json
+++ b/messages/es/settings.json
@@ -564,7 +564,7 @@
     "readMore": "Leer más",
     "detailsTitle": "Detalles de pago",
     "detailsDescription": "Cuenta bancaria y condiciones de pago en las facturas.",
-    "bankAccount": "Cuenta bancaria (IBAN / Til Konto)",
+    "bankAccount": "Cuenta bancaria (IBAN)",
     "bankAccountPlaceholder": "NO93 8601 1117 947",
     "bankAccountHint": "Su numero de cuenta bancaria o IBAN para recibir pagos",
     "paymentTerms": "Condiciones de pago",

--- a/messages/fr/settings.json
+++ b/messages/fr/settings.json
@@ -564,7 +564,7 @@
     "readMore": "En savoir plus",
     "detailsTitle": "Details de paiement",
     "detailsDescription": "Compte bancaire et conditions de paiement sur les factures.",
-    "bankAccount": "Compte bancaire (IBAN / Til Konto)",
+    "bankAccount": "Compte bancaire (IBAN)",
     "bankAccountPlaceholder": "NO93 8601 1117 947",
     "bankAccountHint": "Votre numero de compte bancaire ou IBAN pour recevoir les paiements",
     "paymentTerms": "Conditions de paiement",

--- a/messages/it/pdf.json
+++ b/messages/it/pdf.json
@@ -36,7 +36,7 @@
     "paidInFull": "SALDATO",
     "amountDue": "Importo Dovuto",
     "notes": "Note",
-    "bankAccount": "Til Konto / Conto Bancario",
+    "bankAccount": "Conto Bancario",
     "paymentInformation": "Informazioni di pagamento",
     "orgNumberLabel": "N. org.",
     "paymentTermsLabel": "Condizioni di pagamento",

--- a/messages/it/settings.json
+++ b/messages/it/settings.json
@@ -564,7 +564,7 @@
     "readMore": "Scopri di più",
     "detailsTitle": "Dettagli pagamento",
     "detailsDescription": "Conto bancario e termini di pagamento mostrati sulle fatture.",
-    "bankAccount": "Conto bancario (IBAN / Til Konto)",
+    "bankAccount": "Conto bancario (IBAN)",
     "bankAccountPlaceholder": "NO93 8601 1117 947",
     "bankAccountHint": "Il tuo numero di conto bancario o IBAN per ricevere pagamenti",
     "paymentTerms": "Termini di pagamento",

--- a/messages/nl/pdf.json
+++ b/messages/nl/pdf.json
@@ -36,7 +36,7 @@
     "paidInFull": "VOLLEDIG BETAALD",
     "amountDue": "Te betalen bedrag",
     "notes": "Notities",
-    "bankAccount": "Til Konto / Bankrekening",
+    "bankAccount": "Bankrekening",
     "paymentInformation": "Betalingsinformatie",
     "orgNumberLabel": "Org.nr.",
     "paymentTermsLabel": "Betalingsvoorwaarden",

--- a/messages/nl/settings.json
+++ b/messages/nl/settings.json
@@ -564,7 +564,7 @@
     "readMore": "Lees meer",
     "detailsTitle": "Betalingsgegevens",
     "detailsDescription": "Bankrekening en betalingsvoorwaarden op facturen.",
-    "bankAccount": "Bankrekening (IBAN / Til Konto)",
+    "bankAccount": "Bankrekening (IBAN)",
     "bankAccountPlaceholder": "NO93 8601 1117 947",
     "bankAccountHint": "Uw bankrekeningnummer of IBAN voor het ontvangen van betalingen",
     "paymentTerms": "Betalingsvoorwaarden",

--- a/messages/pl/pdf.json
+++ b/messages/pl/pdf.json
@@ -36,7 +36,7 @@
     "paidInFull": "ZAPŁACONO W CAŁOŚCI",
     "amountDue": "Kwota do zapłaty",
     "notes": "Uwagi",
-    "bankAccount": "Til Konto / Konto bankowe",
+    "bankAccount": "Konto bankowe",
     "paymentInformation": "Informacje o płatności",
     "orgNumberLabel": "Nr org.",
     "paymentTermsLabel": "Warunki płatności",

--- a/messages/pl/settings.json
+++ b/messages/pl/settings.json
@@ -564,7 +564,7 @@
     "readMore": "Czytaj więcej",
     "detailsTitle": "Szczegoly platnosci",
     "detailsDescription": "Konto bankowe i warunki platnosci wyswietlane na fakturach.",
-    "bankAccount": "Konto bankowe (IBAN / Til Konto)",
+    "bankAccount": "Konto bankowe (IBAN)",
     "bankAccountPlaceholder": "NO93 8601 1117 947",
     "bankAccountHint": "Numer konta bankowego lub IBAN do odbierania platnosci",
     "paymentTerms": "Warunki platnosci",

--- a/messages/pt-BR/pdf.json
+++ b/messages/pt-BR/pdf.json
@@ -36,7 +36,7 @@
     "paidInFull": "PAGO INTEGRALMENTE",
     "amountDue": "Valor a Pagar",
     "notes": "Observações",
-    "bankAccount": "Til Konto / Conta Bancária",
+    "bankAccount": "Conta Bancária",
     "paymentInformation": "Informações de pagamento",
     "orgNumberLabel": "Nº da org.",
     "paymentTermsLabel": "Condições de pagamento",

--- a/messages/pt-BR/settings.json
+++ b/messages/pt-BR/settings.json
@@ -564,7 +564,7 @@
     "readMore": "Saiba mais",
     "detailsTitle": "Detalhes de pagamento",
     "detailsDescription": "Conta bancaria e condicoes de pagamento nas faturas.",
-    "bankAccount": "Conta bancaria (IBAN / Til Konto)",
+    "bankAccount": "Conta bancaria (IBAN)",
     "bankAccountPlaceholder": "NO93 8601 1117 947",
     "bankAccountHint": "Seu numero de conta bancaria ou IBAN para receber pagamentos",
     "paymentTerms": "Condicoes de pagamento",

--- a/messages/tr/pdf.json
+++ b/messages/tr/pdf.json
@@ -36,7 +36,7 @@
     "paidInFull": "TAMAMEN ÖDENDİ",
     "amountDue": "Ödenecek Tutar",
     "notes": "Notlar",
-    "bankAccount": "Til Konto / Banka Hesabı",
+    "bankAccount": "Banka Hesabı",
     "paymentInformation": "Ödeme bilgileri",
     "orgNumberLabel": "Org. No.",
     "paymentTermsLabel": "Ödeme koşulları",

--- a/messages/tr/settings.json
+++ b/messages/tr/settings.json
@@ -564,7 +564,7 @@
     "readMore": "Devamını oku",
     "detailsTitle": "Ödeme Bilgileri",
     "detailsDescription": "Faturalarda gösterilen banka hesabı ve ödeme koşulları.",
-    "bankAccount": "Banka Hesabı (IBAN / Til Konto)",
+    "bankAccount": "Banka Hesabı (IBAN)",
     "bankAccountPlaceholder": "NO93 8601 1117 947",
     "bankAccountHint": "Ödeme almak için banka hesap numaranız veya IBAN",
     "paymentTerms": "Ödeme Koşulları",

--- a/src/app/(authenticated)/settings/payment/payment-settings.tsx
+++ b/src/app/(authenticated)/settings/payment/payment-settings.tsx
@@ -123,8 +123,9 @@ export function PaymentSettings({ settings, orgId }: { settings: Record<string, 
 
           <div className="space-y-2">
             <Label htmlFor="bankAccount">{t('payment.bankAccount')}</Label>
-            <Input
+            <Textarea
               id="bankAccount"
+              rows={3}
               placeholder={t('payment.bankAccountPlaceholder')}
               value={bankAccount}
               onChange={(e) => setBankAccount(e.target.value)}

--- a/src/app/(public)/share/invoice/[orgId]/[token]/invoice-view.tsx
+++ b/src/app/(public)/share/invoice/[orgId]/[token]/invoice-view.tsx
@@ -1093,7 +1093,7 @@ export function InvoiceView({
                     {effectiveShowBankAccount && invoiceSettings.bankAccount && (
                       <div>
                         <p className="text-xs text-gray-500 dark:text-gray-400">{t('bankAccount')}</p>
-                        <p className="font-medium">{invoiceSettings.bankAccount}</p>
+                        <p className="whitespace-pre-line font-medium">{invoiceSettings.bankAccount}</p>
                       </div>
                     )}
                     {effectiveShowOrgNumber && invoiceSettings.orgNumber && (

--- a/src/features/vehicles/Components/invoice-pdf/Notes.tsx
+++ b/src/features/vehicles/Components/invoice-pdf/Notes.tsx
@@ -285,9 +285,11 @@ export function BankAccountSection({
             <Text style={{ fontSize: 8, color: '#6b7280', marginBottom: 2 }}>
               {labels.bankAccount || 'Bank Account'}
             </Text>
-            <Text style={{ fontSize: 10, fontFamily: fontBold }}>
-              {invoiceSettings!.bankAccount}
-            </Text>
+            {invoiceSettings!.bankAccount!.split(/\r?\n/).filter((line) => line.trim()).map((line, i) => (
+              <Text key={i} style={{ fontSize: 10, fontFamily: fontBold }}>
+                {line}
+              </Text>
+            ))}
           </View>
         )}
         {hasOrgNumber && (


### PR DESCRIPTION
- Remove the Norwegian 'Til Konto' leak from the bank account label in the en/de/es/fr/it/nl/pl/pt-BR/tr locales (nb keeps it, correctly)
- Turn the bank account setting into a textarea and render each line separately on the invoice PDF and public share view, so details like account name, BSB and account number can be listed on their own lines

Reported in discussion #55.