### PR TITLE
Show invoice date instead of creation date in vehicle and billing views

### DIFF
--- a/src/app/(authenticated)/billing/billing-client.tsx
+++ b/src/app/(authenticated)/billing/billing-client.tsx
@@ -333,7 +333,7 @@ export default function BillingClient({
                       {record.vehicle.customer?.name || "\u2014"}
                     </TableCell>
                     <TableCell>
-                      {formatDate(new Date(record.startDateTime ?? record.serviceDate))}
+                      {formatDate(new Date(record.serviceDate))}
                     </TableCell>
                     <TableCell className="text-right">
                       {fmt(record.totalAmount)}

--- a/src/app/(authenticated)/vehicles/[id]/service-records-table.tsx
+++ b/src/app/(authenticated)/vehicles/[id]/service-records-table.tsx
@@ -27,6 +27,7 @@ import {
 import { typeColors, statusColors } from "@/lib/table-utils";
 import { useFormatCurrency } from '@/components/currency-settings-context'
 import { getWarrantyStatus, type WarrantyStatus } from "@/lib/warranty";
+import { effectiveInvoiceDate } from "@/lib/invoice-utils";
 import {
   ChevronLeft,
   ChevronRight,
@@ -67,6 +68,7 @@ interface ServiceRecordRow {
   mileage: number | null;
   serviceDate: Date;
   startDateTime: Date | null;
+  invoiceDate: Date | null;
   shopName: string | null;
   techName: string | null;
   totalAmount: number;
@@ -276,7 +278,7 @@ export function ServiceRecordsTable({
                     }}
                   >
                     <TableCell className="font-mono text-xs">
-                      {formatDate(new Date(record.serviceDate))}
+                      {formatDate(effectiveInvoiceDate(record))}
                     </TableCell>
                     <TableCell className="max-w-0">
                       <div className="truncate">

--- a/src/app/(authenticated)/vehicles/[id]/vehicle-detail-client.tsx
+++ b/src/app/(authenticated)/vehicles/[id]/vehicle-detail-client.tsx
@@ -106,6 +106,7 @@ interface PaginatedServices {
     mileage: number | null
     serviceDate: Date
     startDateTime: Date | null
+    invoiceDate: Date | null
     shopName: string | null
     techName: string | null
     totalAmount: number

--- a/src/features/billing/Actions/billingActions.ts
+++ b/src/features/billing/Actions/billingActions.ts
@@ -132,6 +132,7 @@ export async function getBillingHistory(params: {
           invoiceNumber: string | null;
           serviceDate: Date;
           startDateTime: Date | null;
+          invoiceDate: Date | null;
           effective_total: number;
           paid_amount: number;
           manually_paid: boolean;
@@ -150,6 +151,7 @@ export async function getBillingHistory(params: {
           sub."invoiceNumber",
           sub."serviceDate",
           sub."startDateTime",
+          sub."invoiceDate",
           sub.effective_total,
           sub.paid_amount,
           sub.manually_paid,
@@ -167,6 +169,7 @@ export async function getBillingHistory(params: {
             sr."invoiceNumber",
             sr."serviceDate",
             sr."startDateTime",
+            sr."invoiceDate",
             sr."manuallyPaid" AS manually_paid,
             CASE WHEN sr."totalAmount" > 0 THEN sr."totalAmount" ELSE sr.cost END AS effective_total,
             CASE WHEN sr."manuallyPaid" = true
@@ -187,7 +190,7 @@ export async function getBillingHistory(params: {
           ${searchCondition}
         ) sub
         WHERE 1=1 ${statusCondition}
-        ORDER BY COALESCE(sub."startDateTime", sub."serviceDate") DESC
+        ORDER BY COALESCE(sub."invoiceDate", sub."startDateTime", sub."serviceDate") DESC
         LIMIT ${pageSize} OFFSET ${skip}
       `);
 
@@ -206,7 +209,7 @@ export async function getBillingHistory(params: {
           title: r.title || "",
           invoiceNumber: r.invoiceNumber,
           startDateTime: r.startDateTime,
-          serviceDate: r.startDateTime ?? r.serviceDate,
+          serviceDate: r.invoiceDate ?? r.startDateTime ?? r.serviceDate,
           totalAmount: effectiveTotal,
           totalPaid: paidAmount,
           status: paymentStatus,
@@ -245,7 +248,11 @@ export async function getBillingHistory(params: {
             },
           },
         },
-        orderBy: { startDateTime: "desc" },
+        orderBy: [
+          { invoiceDate: { sort: "desc", nulls: "last" } },
+          { startDateTime: { sort: "desc", nulls: "last" } },
+          { serviceDate: "desc" },
+        ],
         skip,
         take: pageSize,
       }),
@@ -267,7 +274,7 @@ export async function getBillingHistory(params: {
           title: r.title,
           invoiceNumber: r.invoiceNumber,
           startDateTime: r.startDateTime,
-          serviceDate: r.startDateTime ?? r.serviceDate,
+          serviceDate: r.invoiceDate ?? r.startDateTime ?? r.serviceDate,
           totalAmount: effectiveTotal,
           totalPaid,
           status: paymentStatus,

--- a/src/lib/invoice-utils.ts
+++ b/src/lib/invoice-utils.ts
@@ -5,3 +5,16 @@
 export function resolveInvoicePrefix(prefix: string): string {
   return prefix.replace(/\{year\}/g, String(new Date().getFullYear()));
 }
+
+/**
+ * The date an invoice is presented with: an explicitly set invoice date
+ * wins over the scheduled start, which wins over the service date.
+ * Matches what the invoice PDF and share views print.
+ */
+export function effectiveInvoiceDate(record: {
+  invoiceDate?: Date | string | null;
+  startDateTime?: Date | string | null;
+  serviceDate: Date | string;
+}): Date {
+  return new Date(record.invoiceDate ?? record.startDateTime ?? record.serviceDate);
+}


### PR DESCRIPTION
The vehicle detail service table rendered serviceDate, which is pinned at draft creation and never user-editable, so backdated invoices kept showing the day they were entered. The billing list similarly ignored invoiceDate in its display mapping and ordering.

Both now use the same fallback the invoice PDF and share views already print: invoiceDate ?? startDateTime ?? serviceDate, via a shared effectiveInvoiceDate helper.

Reported in discussion #55.