### PR TITLE
Prefill customer when adding a vehicle from a customer context

### DIFF
--- a/src/__tests__/multitenancy/vehicle-service-isolation.test.ts
+++ b/src/__tests__/multitenancy/vehicle-service-isolation.test.ts
@@ -106,14 +106,14 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("getVehicle — cross-org isolation", () => {
-  it("returns 'Vehicle not found' error when requesting another org's vehicle ID", async () => {
+  it("returns null (no data) when requesting another org's vehicle ID", async () => {
     setupOrgAOwner();
     vi.mocked(db.vehicle.findFirst).mockResolvedValue(null);
 
     const result = await getVehicle(`${ORG_B}-vehicle-id`);
 
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("Vehicle not found");
+    expect(result.success).toBe(true);
+    expect(result.data).toBeNull();
   });
 
   it("returns vehicle data for a vehicle that belongs to the caller's org", async () => {

--- a/src/app/(authenticated)/customers/[id]/customer-detail-client.tsx
+++ b/src/app/(authenticated)/customers/[id]/customer-detail-client.tsx
@@ -39,6 +39,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { SmsConversation } from "@/features/sms/Components/SmsConversation";
 import { TelegramConversation } from "@/features/telegram/Components/TelegramConversation";
 import { CustomerForm } from "@/features/customers/Components/CustomerForm";
+import { VehicleForm } from "@/features/vehicles/Components/VehicleForm";
 import { updateServiceRequest, createWorkOrderFromRequest } from "@/features/customers/Actions/customerActions";
 import { SendSmsDialog } from "@/features/sms/Components/SendSmsDialog";
 import { TelegramQrCode } from "@/features/telegram/Components/TelegramQrCode";
@@ -89,6 +90,7 @@ interface SmsMessage {
 
 export function CustomerDetailClient({
   customer,
+  customers = [],
   unitSystem = "imperial",
   smsEnabled = false,
   smsMessages = [],
@@ -100,6 +102,7 @@ export function CustomerDetailClient({
   telegramChatId = null,
 }: {
   customer: CustomerDetail;
+  customers?: { id: string; name: string; company: string | null }[];
   unitSystem?: "metric" | "imperial";
   smsEnabled?: boolean;
   smsMessages?: SmsMessage[];
@@ -116,6 +119,7 @@ export function CustomerDetailClient({
   const router = useRouter();
   const searchParams = useSearchParams();
   const [showEditForm, setShowEditForm] = useState(false);
+  const [showVehicleForm, setShowVehicleForm] = useState(false);
 
   const tabParam = searchParams.get("tab");
   const activeTab =
@@ -302,13 +306,17 @@ export function CustomerDetailClient({
         {activeTab === "vehicles" && (
           <>
             <div className="mb-3 flex justify-end">
-              <Button size="sm" asChild>
-                <Link href={`/vehicles?create=true&customerId=${customer.id}`}>
-                  <Plus className="mr-1 h-4 w-4" />
-                  {tVehicles("addVehicle")}
-                </Link>
+              <Button size="sm" onClick={() => setShowVehicleForm(true)}>
+                <Plus className="mr-1 h-4 w-4" />
+                {tVehicles("addVehicle")}
               </Button>
             </div>
+            <VehicleForm
+              open={showVehicleForm}
+              onOpenChange={setShowVehicleForm}
+              customers={customers}
+              defaultCustomerId={customer.id}
+            />
             {customer.vehicles.length === 0 ? (
               <Card className="border-dashed">
                 <CardContent className="flex flex-col items-center py-12">

--- a/src/app/(authenticated)/customers/[id]/customer-detail-client.tsx
+++ b/src/app/(authenticated)/customers/[id]/customer-detail-client.tsx
@@ -342,7 +342,7 @@ export function CustomerDetailClient({
                       <TableRow
                         key={v.id}
                         className="cursor-pointer"
-                        onClick={() => router.push(`/vehicles/${v.id}`)}
+                        onClick={() => router.push(`/vehicles/${v.id}?back=${encodeURIComponent(`/customers/${customer.id}`)}`)}
                       >
                         <TableCell className="font-mono text-sm">
                           {v.licensePlate || "-"}

--- a/src/app/(authenticated)/customers/[id]/customer-detail-client.tsx
+++ b/src/app/(authenticated)/customers/[id]/customer-detail-client.tsx
@@ -111,6 +111,7 @@ export function CustomerDetailClient({
   telegramChatId?: string | null;
 }) {
   const t = useTranslations("customers.detail");
+  const tVehicles = useTranslations("vehicles.list");
   const serviceType = useServiceType();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -300,6 +301,14 @@ export function CustomerDetailClient({
 
         {activeTab === "vehicles" && (
           <>
+            <div className="mb-3 flex justify-end">
+              <Button size="sm" asChild>
+                <Link href={`/vehicles?create=true&customerId=${customer.id}`}>
+                  <Plus className="mr-1 h-4 w-4" />
+                  {tVehicles("addVehicle")}
+                </Link>
+              </Button>
+            </div>
             {customer.vehicles.length === 0 ? (
               <Card className="border-dashed">
                 <CardContent className="flex flex-col items-center py-12">

--- a/src/app/(authenticated)/customers/[id]/page.tsx
+++ b/src/app/(authenticated)/customers/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { getTranslations } from "next-intl/server";
-import { getCustomer } from "@/features/customers/Actions/customerActions";
+import { getCustomer, getCustomersList } from "@/features/customers/Actions/customerActions";
 import { getSettings } from "@/features/settings/Actions/settingsActions";
 import { SETTING_KEYS } from "@/features/settings/Schema/settingsSchema";
 import { getConversation } from "@/features/sms/Actions/smsActions";
@@ -17,10 +17,11 @@ export default async function CustomerDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const [result, settingsResult, layoutData] = await Promise.all([
+  const [result, settingsResult, layoutData, customersResult] = await Promise.all([
     getCustomer(id),
     getSettings([SETTING_KEYS.UNIT_SYSTEM]),
     getLayoutData(),
+    getCustomersList(),
   ]);
 
   if (!result.success || !result.data) {
@@ -82,6 +83,7 @@ export default async function CustomerDetailPage({
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
         <CustomerDetailClient
           customer={result.data}
+          customers={customersResult.success && customersResult.data ? customersResult.data : []}
           unitSystem={(settingsResult.success && settingsResult.data?.[SETTING_KEYS.UNIT_SYSTEM] || "imperial") as "metric" | "imperial"}
           smsEnabled={smsEnabled}
           smsMessages={smsMessages}

--- a/src/app/(authenticated)/vehicles/[id]/vehicle-detail-client.tsx
+++ b/src/app/(authenticated)/vehicles/[id]/vehicle-detail-client.tsx
@@ -291,6 +291,11 @@ export function VehicleDetailClient({
     ? (tabParam as string)
     : 'services'
 
+  // Where to return after leaving this page (e.g. arrived from a customer
+  // page). Restricted to internal paths; tab changes preserve the param.
+  const rawBack = searchParams.get('back')
+  const backHref = rawBack && rawBack.startsWith('/') && !rawBack.startsWith('//') ? rawBack : '/vehicles'
+
   const handleTabChange = useCallback(
     (value: string) => {
       const params = new URLSearchParams(searchParams.toString())
@@ -499,7 +504,7 @@ export function VehicleDetailClient({
     const result = await deleteVehicle(vehicle.id)
     if (result.success) {
       toast.success(t('vehicleDeleted'))
-      router.push('/vehicles')
+      router.push(backHref)
     } else {
       modal.open('error', 'Error', result.error || t('vehicleDeleteError'))
     }
@@ -528,11 +533,11 @@ export function VehicleDetailClient({
       <div className="space-y-3">
         <div className="flex items-center justify-between">
           <Link
-            href="/vehicles"
+            href={backHref}
             className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             <ArrowLeft className="h-4 w-4" />
-            {t('backToVehicles')}
+            {rawBack ? tc('back') : t('backToVehicles')}
           </Link>
           <div className="flex items-center gap-2">
             {!vehicle.isArchived && (

--- a/src/app/(authenticated)/vehicles/vehicles-client.tsx
+++ b/src/app/(authenticated)/vehicles/vehicles-client.tsx
@@ -107,6 +107,7 @@ export function VehiclesClient({
   const t = useTranslations('vehicles.list')
   const tc = useTranslations('common.buttons')
   const [showForm, setShowForm] = useState(false)
+  const [createCustomerId, setCreateCustomerId] = useState<string | undefined>(undefined)
   const [editVehicle, setEditVehicle] = useState<Vehicle | null>(null)
   const [view, setView] = useState<'table' | 'grid' | 'grid6'>(initialView)
   const [archiveTarget, setArchiveTarget] = useState<{ id: string; name: string } | null>(null)
@@ -115,9 +116,11 @@ export function VehiclesClient({
 
   useEffect(() => {
     if (searchParams.get('create') === 'true') {
+      setCreateCustomerId(searchParams.get('customerId') || undefined)
       setShowForm(true)
       const params = new URLSearchParams(searchParams.toString())
       params.delete('create')
+      params.delete('customerId')
       const cleanUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname
       window.history.replaceState(null, '', cleanUrl)
     }
@@ -498,10 +501,14 @@ export function VehiclesClient({
         open={showForm}
         onOpenChange={(open) => {
           setShowForm(open)
-          if (!open) setEditVehicle(null)
+          if (!open) {
+            setEditVehicle(null)
+            setCreateCustomerId(undefined)
+          }
         }}
         vehicle={editVehicle ?? undefined}
         customers={customers}
+        defaultCustomerId={createCustomerId}
       />
 
       <ArchiveVehicleDialog

--- a/src/features/vehicles/Actions/findingActions.ts
+++ b/src/features/vehicles/Actions/findingActions.ts
@@ -136,14 +136,18 @@ export async function getVehicleFindings(
 ) {
   return withAuth(
     async ({ organizationId }) => {
-      const vehicle = await db.vehicle.findFirst({
-        where: { id: vehicleId, organizationId },
-      });
-      if (!vehicle) throw new Error("Vehicle not found");
-
       const page = params.page || 1;
       const pageSize = params.pageSize || 10;
       const skip = (page - 1) * pageSize;
+
+      const vehicle = await db.vehicle.findFirst({
+        where: { id: vehicleId, organizationId },
+      });
+      // Deleted or foreign-org vehicle: empty result instead of an error, since
+      // this runs during the post-delete re-render of the vehicle page.
+      if (!vehicle) {
+        return { records: [], total: 0, page, pageSize, totalPages: 0 };
+      }
 
       const [records, total] = await Promise.all([
         db.vehicleFinding.findMany({

--- a/src/features/vehicles/Actions/noteActions.ts
+++ b/src/features/vehicles/Actions/noteActions.ts
@@ -11,14 +11,18 @@ export async function getNotesPaginated(
   params: { page?: number; pageSize?: number }
 ) {
   return withAuth(async ({ organizationId }) => {
-    const vehicle = await db.vehicle.findFirst({
-      where: { id: vehicleId, organizationId },
-    });
-    if (!vehicle) throw new Error("Vehicle not found");
-
     const page = params.page || 1;
     const pageSize = params.pageSize || 10;
     const skip = (page - 1) * pageSize;
+
+    const vehicle = await db.vehicle.findFirst({
+      where: { id: vehicleId, organizationId },
+    });
+    // Deleted or foreign-org vehicle: empty result instead of an error, since
+    // this runs during the post-delete re-render of the vehicle page.
+    if (!vehicle) {
+      return { records: [], total: 0, page, pageSize, totalPages: 0 };
+    }
 
     const [records, total] = await Promise.all([
       db.note.findMany({

--- a/src/features/vehicles/Actions/serviceActions.ts
+++ b/src/features/vehicles/Actions/serviceActions.ts
@@ -40,14 +40,18 @@ export async function getServiceRecordsPaginated(
   }
 ) {
   return withAuth(async ({ organizationId }) => {
-    const vehicle = await db.vehicle.findFirst({
-      where: { id: vehicleId, organizationId },
-    });
-    if (!vehicle) throw new Error("Vehicle not found");
-
     const page = params.page || 1;
     const pageSize = params.pageSize || 10;
     const skip = (page - 1) * pageSize;
+
+    const vehicle = await db.vehicle.findFirst({
+      where: { id: vehicleId, organizationId },
+    });
+    // Deleted or foreign-org vehicle: empty result instead of an error, since
+    // this runs during the post-delete re-render of the vehicle page.
+    if (!vehicle) {
+      return { records: [], total: 0, page, pageSize, totalPages: 0 };
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const where: any = { vehicleId };

--- a/src/features/vehicles/Actions/vehicleActions.ts
+++ b/src/features/vehicles/Actions/vehicleActions.ts
@@ -63,7 +63,9 @@ export async function getVehicle(vehicleId: string) {
       },
     });
 
-    if (!vehicle) throw new Error("Vehicle not found");
+    // Missing or foreign-org vehicle yields null rather than an error: the
+    // page renders its not-found state, and this also runs during the
+    // post-delete re-render of the vehicle route.
     return vehicle;
   }, { requiredPermissions: [{ action: PermissionAction.READ, subject: PermissionSubject.VEHICLES }] });
 }

--- a/src/features/vehicles/Components/VehicleForm.tsx
+++ b/src/features/vehicles/Components/VehicleForm.tsx
@@ -63,9 +63,11 @@ interface VehicleFormProps {
     customerId?: string | null;
   };
   customers?: { id: string; name: string; company: string | null }[];
+  /** Preselects the customer when creating a new vehicle (ignored when editing) */
+  defaultCustomerId?: string;
 }
 
-export function VehicleForm({ open, onOpenChange, vehicle, customers }: VehicleFormProps) {
+export function VehicleForm({ open, onOpenChange, vehicle, customers, defaultCustomerId }: VehicleFormProps) {
   const serviceType = useServiceType();
   const isMarine = serviceType === "marine";
   const router = useRouter();
@@ -76,7 +78,7 @@ export function VehicleForm({ open, onOpenChange, vehicle, customers }: VehicleF
   const [preview, setPreview] = useState<string | null>(vehicle?.imageUrl ?? null);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [selectedCustomerId, setSelectedCustomerId] = useState<string>(
-    vehicle?.customerId || "none"
+    vehicle?.customerId || defaultCustomerId || "none"
   );
   const [customerOpen, setCustomerOpen] = useState(false);
   const [showCustomerForm, setShowCustomerForm] = useState(false);
@@ -85,10 +87,10 @@ export function VehicleForm({ open, onOpenChange, vehicle, customers }: VehicleF
 
   // Sync state when vehicle prop changes (e.g. opening edit for a different vehicle)
   useEffect(() => {
-    setSelectedCustomerId(vehicle?.customerId || "none");
+    setSelectedCustomerId(vehicle?.customerId || defaultCustomerId || "none");
     setPreview(vehicle?.imageUrl ?? null);
     setImageFile(null);
-  }, [vehicle?.id, vehicle?.customerId, vehicle?.imageUrl]);
+  }, [vehicle?.id, vehicle?.customerId, vehicle?.imageUrl, defaultCustomerId]);
 
   const selectedCustomerLabel = useMemo(() => {
     if (!selectedCustomerId || selectedCustomerId === "none") return t("noCustomer");


### PR DESCRIPTION
The vehicles page now accepts a customerId param that preselects the customer in the vehicle form.
The customer detail page gets an Add Vehicle button using it, so the customer no longer has to be reselected.
