### PR TITLE
Make the work order line-item editors usable on small screens

### DIFF
--- a/src/app/(authenticated)/work-orders/work-orders-client.tsx
+++ b/src/app/(authenticated)/work-orders/work-orders-client.tsx
@@ -274,16 +274,19 @@ export function WorkOrdersClient({
           </form>
           {isPending && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
         </div>
-        <Button size="sm" onClick={() => setShowPicker(true)}>
-          <Plus className="mr-1 h-3.5 w-3.5" />
-          {t("newWorkOrder")}
+        <Button size="sm" className="shrink-0" onClick={() => setShowPicker(true)}>
+          <Plus className="h-3.5 w-3.5 sm:mr-1" />
+          <span className="hidden sm:inline">{t("newWorkOrder")}</span>
         </Button>
       </div>
 
       {/* Table */}
       <div className="rounded-lg border">
         <TableContextMenuHint />
-        <Table className="table-fixed">
+        {/* Low-priority columns drop out at sm/md/lg; the min-width stops what
+            is left from being squeezed to a few characters, scrolling the
+            table sideways instead (the Table wrapper handles the overflow) */}
+        <Table className="min-w-[36rem] table-fixed">
           <TableHeader>
             <TableRow>
               <TableHead className="hidden sm:table-cell w-[100px]">

--- a/src/components/icon-action-button.tsx
+++ b/src/components/icon-action-button.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import type { LucideIcon } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+type ButtonProps = React.ComponentProps<typeof Button>
+
+export interface IconActionButtonProps extends Omit<ButtonProps, 'children' | 'size'> {
+  /** Translated action name. Used as the tooltip and the accessible name. */
+  label: string
+  icon: LucideIcon
+  /** Shows a spinner in place of the icon and blocks the click. */
+  loading?: boolean
+  size?: 'icon-xs' | 'icon-sm' | 'icon' | 'icon-lg'
+  /** Small overlay on the icon, e.g. a count of open observations. */
+  badge?: React.ReactNode
+}
+
+/**
+ * Icon-only action button with the label in a tooltip.
+ *
+ * Toolbars carry the same set of actions in twelve languages, and labels like
+ * "Fra varelageret" or "Kundenbenachrichtigung" blow the row apart on a phone.
+ * Dropping to the icon keeps every toolbar the same width in every language;
+ * the label still reaches pointer users through the tooltip and screen reader
+ * users through the accessible name.
+ */
+export function IconActionButton({
+  label,
+  icon: Icon,
+  loading = false,
+  size = 'icon-sm',
+  variant = 'outline',
+  className,
+  disabled,
+  badge,
+  ...props
+}: IconActionButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          aria-label={label}
+          variant={variant}
+          size={size}
+          disabled={disabled || loading}
+          className={cn('relative', className)}
+          {...props}
+        >
+          {loading ? <Loader2 className="size-4 animate-spin" /> : <Icon className="size-4" />}
+          {badge}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/components/line-item-field.tsx
+++ b/src/components/line-item-field.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+interface FieldRowProps {
+  /** Column name, shown beside the control while the table is stacked. */
+  label: string
+  /** Optional explanation, surfaced on hover of the label. */
+  hint?: string
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * One cell of a line-item editor (parts, labor, quote lines).
+ *
+ * Below `lg` the editors stack into cards, where a bare column of number
+ * inputs gives no clue which box is the price and which is the markup, so each
+ * control keeps its column name beside it. From `lg` up the wrapper collapses
+ * to `display: contents` and the control drops straight into the parent grid,
+ * under the shared header row.
+ */
+export function FieldRow({ label, hint, className, children }: FieldRowProps) {
+  return (
+    <div className={cn('flex items-center gap-2 lg:contents', className)}>
+      <span className="w-24 shrink-0 text-xs text-muted-foreground lg:hidden" title={hint}>
+        {label}
+      </span>
+      {children}
+    </div>
+  )
+}

--- a/src/features/vehicles/Components/service-edit/LaborEditor.tsx
+++ b/src/features/vehicles/Components/service-edit/LaborEditor.tsx
@@ -5,6 +5,9 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { AlertTriangle, Eye, GripVertical, Layers, Plus, Trash2, Wrench } from 'lucide-react'
+import { IconActionButton } from '@/components/icon-action-button'
+import { FieldRow } from '@/components/line-item-field'
+import { cn } from '@/lib/utils'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -55,6 +58,7 @@ function SortableLaborRow({
   updateLabor,
   onDelete,
   currencyCode,
+  rateLabel,
   t,
   dragEnabled,
 }: {
@@ -64,6 +68,8 @@ function SortableLaborRow({
   updateLabor: (index: number, field: keyof ServiceLaborInput, value: string | number) => void
   onDelete: () => void
   currencyCode: string
+  /** Pre-formatted "Rate (kr/hr)" header, which needs the currency symbol. */
+  rateLabel: string
   t: (key: string) => string
   dragEnabled: boolean
 }) {
@@ -88,7 +94,13 @@ function SortableLaborRow({
     <div
       ref={dragEnabled ? setNodeRef : undefined}
       style={style}
-      className={`grid grid-cols-[auto_1fr] gap-2 sm:grid-cols-[auto_2fr_1fr_1fr_1fr_auto] ${isDragging && dragEnabled ? 'z-10 opacity-75' : ''}`}
+      className={cn(
+        // Stacked card while the editor is narrow, one table row once its
+        // container is wide enough to hold every column at a usable size
+        'grid grid-cols-[auto_1fr] gap-2 rounded-lg border p-2',
+        '@2xl:grid-cols-[auto_2fr_1fr_1fr_1fr_auto] @2xl:rounded-none @2xl:border-0 @2xl:p-0',
+        isDragging && dragEnabled && 'z-10 opacity-75',
+      )}
     >
       <button
         type="button"
@@ -97,8 +109,8 @@ function SortableLaborRow({
       >
         <GripVertical className="h-4 w-4" />
       </button>
-      <div className="grid grid-cols-2 gap-2 sm:contents">
-        <div className="col-span-2 flex gap-2 sm:col-span-1">
+      <div className="flex min-w-0 flex-col gap-2 @2xl:contents">
+        <div className="flex gap-2">
           <Textarea
             placeholder={t('descriptionPlaceholder')}
             value={labor.description}
@@ -119,34 +131,43 @@ function SortableLaborRow({
             {isService ? t('serviceTag') : t('hourlyTag')}
           </button>
         </div>
-        <Input
-          type="number"
-          min="0"
-          step={isService ? '1' : 'any'}
-          placeholder={isService ? t('qty') : t('hours')}
-          value={labor.hours}
-          onChange={(e) => updateLabor(index, 'hours', e.target.value)}
-        />
-        <Input
-          type="number"
-          min="0"
-          step="0.01"
-          value={labor.rate}
-          onChange={(e) => updateLabor(index, 'rate', e.target.value)}
-        />
-        <div className="flex items-center rounded-md bg-muted/50 px-3 text-sm font-medium">
-          {formatCurrency(labor.total, currencyCode)}
+        <FieldRow label={isService ? t('qty') : t('hours')}>
+          <Input
+            type="number"
+            min="0"
+            step={isService ? '1' : 'any'}
+            placeholder={isService ? t('qty') : t('hours')}
+            value={labor.hours}
+            onChange={(e) => updateLabor(index, 'hours', e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={rateLabel}>
+          <Input
+            type="number"
+            min="0"
+            step="0.01"
+            value={labor.rate}
+            onChange={(e) => updateLabor(index, 'rate', e.target.value)}
+          />
+        </FieldRow>
+        <div className="flex items-center gap-2 @2xl:contents">
+          <span className="w-24 shrink-0 text-xs text-muted-foreground @2xl:hidden">
+            {t('total')}
+          </span>
+          <div className="flex h-9 flex-1 items-center rounded-md bg-muted/50 px-3 text-sm font-medium">
+            {formatCurrency(labor.total, currencyCode)}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9 shrink-0 text-muted-foreground hover:text-destructive"
+            onClick={onDelete}
+            aria-label={t('deleteRow')}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
         </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-9 w-9 text-muted-foreground hover:text-destructive"
-          onClick={onDelete}
-          aria-label={t('deleteRow')}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
       </div>
     </div>
   )
@@ -227,41 +248,41 @@ export function LaborEditor({
   }, [setLaborItems])
 
   return (
-    <div className="rounded-lg border p-3 space-y-2">
+    // Sizes itself off its own container: the details view splits into two
+    // resizable columns, so this editor can be narrower on a wide screen than
+    // it is on a phone.
+    <div className="@container space-y-2 rounded-lg border p-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-sm font-semibold">{t('title')}</h3>
         <div className="flex flex-wrap gap-1.5">
           {hasPresets && onOpenPresets && (
-            <Button type="button" variant="outline" size="sm" onClick={onOpenPresets}>
-              <Layers className="mr-1 h-3.5 w-3.5" />
-              <span className="hidden sm:inline">{t('fromPresets')}</span>
-            </Button>
+            <IconActionButton
+              label={t('fromPresets')}
+              icon={Layers}
+              onClick={onOpenPresets}
+            />
           )}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={addLaborAtStart}
-          >
-            <Plus className="mr-1 h-3.5 w-3.5" />
-            <span className="hidden sm:inline">{t('addLabor')}</span>
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
+          <IconActionButton label={t('addLabor')} icon={Plus} onClick={addLaborAtStart} />
+          <IconActionButton
+            label={t('addService')}
+            icon={Wrench}
             onClick={addServiceAtStart}
-          >
-            <Wrench className="mr-1 h-3.5 w-3.5" />
-            <span className="hidden sm:inline">{t('addService')}</span>
-          </Button>
+          />
           {onAddFinding && openObservationsCount > 0 && onShowExistingObservations ? (
             <DropdownMenu>
+              {/* Plain button with a native tooltip: a Radix dropdown trigger
+                  cannot wrap a Tooltip root, only the button inside it */}
               <DropdownMenuTrigger asChild>
-                <Button type="button" variant="outline" size="sm">
-                  <AlertTriangle className="mr-1 h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">{t('addFinding')}</span>
-                  <span className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500 px-1 text-[10px] font-medium text-white">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  className="relative"
+                  aria-label={t('addFinding')}
+                  title={t('addFinding')}
+                >
+                  <AlertTriangle className="size-4" />
+                  <span className="absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500 px-1 text-[10px] font-medium text-white">
                     {openObservationsCount}
                   </span>
                 </Button>
@@ -282,22 +303,18 @@ export function LaborEditor({
               </DropdownMenuContent>
             </DropdownMenu>
           ) : onAddFinding ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
+            <IconActionButton
+              label={t('addFinding')}
+              icon={AlertTriangle}
               onClick={onAddFinding}
-            >
-              <AlertTriangle className="mr-1 h-3.5 w-3.5" />
-              <span className="hidden sm:inline">{t('addFinding')}</span>
-            </Button>
+            />
           ) : null}
         </div>
       </div>
 
       {laborItems.length > 0 && (
         <>
-          <div className="hidden grid-cols-[auto_2fr_1fr_1fr_1fr_auto] gap-2 text-xs font-medium text-muted-foreground sm:grid">
+          <div className="hidden grid-cols-[auto_2fr_1fr_1fr_1fr_auto] gap-2 text-xs font-medium text-muted-foreground @2xl:grid">
             <span className="w-6" />
             <span>{t('description')}</span>
             <span>{t('qtyOrHours')}</span>
@@ -317,6 +334,7 @@ export function LaborEditor({
                     updateLabor={updateLabor}
                     onDelete={() => deleteLabor(i)}
                     currencyCode={currencyCode}
+                    rateLabel={t('rate', { currency: cs })}
                     t={t}
                     dragEnabled
                   />
@@ -333,6 +351,7 @@ export function LaborEditor({
                 updateLabor={updateLabor}
                 onDelete={() => deleteLabor(i)}
                 currencyCode={currencyCode}
+                rateLabel={t('rate', { currency: cs })}
                 t={t}
                 dragEnabled={false}
               />

--- a/src/features/vehicles/Components/service-edit/PartsEditor.tsx
+++ b/src/features/vehicles/Components/service-edit/PartsEditor.tsx
@@ -5,6 +5,9 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { GripVertical, Package, Percent, Plus, ScanBarcode, Trash2 } from 'lucide-react'
+import { IconActionButton } from '@/components/icon-action-button'
+import { FieldRow } from '@/components/line-item-field'
+import { cn } from '@/lib/utils'
 import { useFormatCurrency } from '@/components/currency-settings-context'
 import { useTranslations } from 'next-intl'
 import type { ServicePartInput } from '@/features/vehicles/Schema/serviceSchema'
@@ -96,11 +99,21 @@ function SortablePartRow({
     transition,
   } : undefined
 
+  const nameMissing =
+    !part.name.trim() &&
+    !!(part.partNumber || Number(part.unitCost) > 0 || Number(part.unitPrice) > 0)
+
   return (
     <div
       ref={dragEnabled ? setNodeRef : undefined}
       style={style}
-      className={`grid grid-cols-[auto_1fr] gap-2 sm:grid-cols-[auto_1fr_2fr_0.6fr_0.9fr_0.7fr_0.9fr_0.9fr_auto] ${isDragging && dragEnabled ? 'z-10 opacity-75' : ''}`}
+      className={cn(
+        // Stacked card while the editor is narrow, one table row once its
+        // container is wide enough to hold every column at a usable size
+        'grid grid-cols-[auto_1fr] gap-2 rounded-lg border p-2',
+        '@2xl:grid-cols-[auto_1fr_2fr_0.6fr_0.9fr_0.7fr_0.9fr_0.9fr_auto] @2xl:rounded-none @2xl:border-0 @2xl:p-0',
+        isDragging && dragEnabled && 'z-10 opacity-75',
+      )}
     >
       <button
         type="button"
@@ -109,80 +122,102 @@ function SortablePartRow({
       >
         <GripVertical className="h-4 w-4" />
       </button>
-      <div className="grid grid-cols-2 gap-2 sm:contents">
-        <Input
-          placeholder={t('partNumber')}
-          value={part.partNumber ?? ''}
-          onChange={(e) => updatePart(index, 'partNumber', e.target.value)}
-        />
-        <div className="relative">
-          <Textarea
-            placeholder={t('namePlaceholder')}
-            value={part.name}
-            onChange={(e) => updatePart(index, 'name', e.target.value)}
-            rows={1}
-            aria-invalid={!part.name.trim() && !!(part.partNumber || Number(part.unitCost) > 0 || Number(part.unitPrice) > 0)}
-            className={`min-h-9 w-full resize-none ${!part.name.trim() && (part.partNumber || Number(part.unitCost) > 0 || Number(part.unitPrice) > 0) ? 'border-destructive focus-visible:ring-destructive' : ''}`}
+      <div className="flex min-w-0 flex-col gap-2 @2xl:contents">
+        <FieldRow label={t('partNumber')}>
+          <Input
+            placeholder={t('partNumber')}
+            value={part.partNumber ?? ''}
+            onChange={(e) => updatePart(index, 'partNumber', e.target.value)}
           />
-          <PartNameSuggestions
-            query={part.name}
-            parts={inventoryParts}
-            disabled={!!part.inventoryPartId}
-            currencyCode={currencyCode}
-            defaultMarkupPercent={defaultMarkupPercent}
-            markupAppliesToInventory={markupAppliesToInventory}
-            onSelect={(picked) => onSelectSuggestion(index, picked)}
-          />
-        </div>
-        <Input
-          type="number"
-          min="0"
-          step="0.1"
-          value={part.quantity}
-          onChange={(e) => updatePart(index, 'quantity', e.target.value)}
-        />
-        <Input
-          type="number"
-          min="0"
-          step="0.01"
-          placeholder={t('unitCost')}
-          title={t('unitCostHint')}
-          value={part.unitCost ?? 0}
-          onChange={(e) => updatePart(index, 'unitCost', e.target.value)}
-        />
-        <div className="relative">
+        </FieldRow>
+        {/* The name identifies the row, so it leads the stacked card even
+            though the part number comes first in the desktop grid */}
+        <FieldRow label={t('name')} className="order-first @2xl:order-none">
+          <div className="relative w-full">
+            <Textarea
+              placeholder={t('namePlaceholder')}
+              value={part.name}
+              onChange={(e) => updatePart(index, 'name', e.target.value)}
+              rows={1}
+              aria-invalid={nameMissing}
+              className={cn(
+                'min-h-9 w-full resize-none',
+                nameMissing && 'border-destructive focus-visible:ring-destructive',
+              )}
+            />
+            <PartNameSuggestions
+              query={part.name}
+              parts={inventoryParts}
+              disabled={!!part.inventoryPartId}
+              currencyCode={currencyCode}
+              defaultMarkupPercent={defaultMarkupPercent}
+              markupAppliesToInventory={markupAppliesToInventory}
+              onSelect={(picked) => onSelectSuggestion(index, picked)}
+            />
+          </div>
+        </FieldRow>
+        <FieldRow label={t('qty')}>
           <Input
             type="number"
             min="0"
             step="0.1"
-            placeholder={t('markupPercent')}
-            title={t('markupPercentHint')}
-            value={part.markupPercent ?? 0}
-            onChange={(e) => updatePart(index, 'markupPercent', e.target.value)}
-            className="pr-6"
+            value={part.quantity}
+            onChange={(e) => updatePart(index, 'quantity', e.target.value)}
           />
-          <Percent className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+        </FieldRow>
+        <FieldRow label={t('unitCost')} hint={t('unitCostHint')}>
+          <Input
+            type="number"
+            min="0"
+            step="0.01"
+            placeholder={t('unitCost')}
+            title={t('unitCostHint')}
+            value={part.unitCost ?? 0}
+            onChange={(e) => updatePart(index, 'unitCost', e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={t('markupPercent')} hint={t('markupPercentHint')}>
+          <div className="relative w-full">
+            <Input
+              type="number"
+              min="0"
+              step="0.1"
+              placeholder={t('markupPercent')}
+              title={t('markupPercentHint')}
+              value={part.markupPercent ?? 0}
+              onChange={(e) => updatePart(index, 'markupPercent', e.target.value)}
+              className="pr-6"
+            />
+            <Percent className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+          </div>
+        </FieldRow>
+        <FieldRow label={t('unitPrice')}>
+          <Input
+            type="number"
+            min="0"
+            step="0.01"
+            value={part.unitPrice}
+            onChange={(e) => updatePart(index, 'unitPrice', e.target.value)}
+          />
+        </FieldRow>
+        <div className="flex items-center gap-2 @2xl:contents">
+          <span className="w-24 shrink-0 text-xs text-muted-foreground @2xl:hidden">
+            {t('total')}
+          </span>
+          <div className="flex h-9 flex-1 items-center rounded-md bg-muted/50 px-3 text-sm font-medium">
+            {formatCurrency(part.total, currencyCode)}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9 shrink-0 text-muted-foreground hover:text-destructive"
+            onClick={onDelete}
+            aria-label={t('deleteRow')}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
         </div>
-        <Input
-          type="number"
-          min="0"
-          step="0.01"
-          value={part.unitPrice}
-          onChange={(e) => updatePart(index, 'unitPrice', e.target.value)}
-        />
-        <div className="flex items-center rounded-md bg-muted/50 px-3 text-sm font-medium">
-          {formatCurrency(part.total, currencyCode)}
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-9 w-9 text-muted-foreground hover:text-destructive"
-          onClick={onDelete}
-          aria-label={t('deleteRow')}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
       </div>
     </div>
   )
@@ -306,51 +341,41 @@ export function PartsEditor({
   }, [setPartItems, defaultMarkupPercent, markupAppliesToInventory])
 
   return (
-    <div className="rounded-lg border p-3 space-y-2">
-      <div className="flex items-center justify-between">
+    // The details view splits into two resizable columns, so this editor can
+    // be narrower on a wide screen than it is on a phone. It sizes itself off
+    // its own container rather than the viewport.
+    <div className="@container space-y-2 rounded-lg border p-3">
+      <div className="flex items-center justify-between gap-2">
         <h3 className="text-sm font-semibold">{t('title')}</h3>
         <div className="flex gap-1.5">
           {defaultMarkupPercent > 0 && partItems.length > 0 && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
+            <IconActionButton
+              label={t('applyMarkup', { percent: defaultMarkupPercent })}
+              icon={Percent}
               onClick={applyMarkupToAll}
-              title={t('applyMarkupHint', { percent: defaultMarkupPercent })}
-            >
-              <Percent className="h-3.5 w-3.5 sm:mr-1" />
-              <span className="hidden sm:inline">
-                {t('applyMarkup', { percent: defaultMarkupPercent })}
-              </span>
-            </Button>
+            />
           )}
           {hasInventory && (
-            <Button type="button" variant="outline" size="sm" onClick={onOpenInventory}>
-              <Package className="h-3.5 w-3.5 sm:mr-1" />
-              <span className="hidden sm:inline">{t('fromInventory')}</span>
-            </Button>
+            <IconActionButton
+              label={t('fromInventory')}
+              icon={Package}
+              onClick={onOpenInventory}
+            />
           )}
           {onScanBarcode && (
-            <Button type="button" variant="outline" size="sm" onClick={onScanBarcode}>
-              <ScanBarcode className="h-3.5 w-3.5 sm:mr-1" />
-              <span className="hidden sm:inline">{t('scanBarcode')}</span>
-            </Button>
+            <IconActionButton
+              label={t('scanBarcode')}
+              icon={ScanBarcode}
+              onClick={onScanBarcode}
+            />
           )}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={addPartAtStart}
-          >
-            <Plus className="h-3.5 w-3.5 sm:mr-1" />
-            <span className="hidden sm:inline">{t('addPart')}</span>
-          </Button>
+          <IconActionButton label={t('addPart')} icon={Plus} onClick={addPartAtStart} />
         </div>
       </div>
 
       {partItems.length > 0 && (
         <>
-          <div className="hidden grid-cols-[auto_1fr_2fr_0.6fr_0.9fr_0.7fr_0.9fr_0.9fr_auto] gap-2 text-xs font-medium text-muted-foreground sm:grid">
+          <div className="hidden grid-cols-[auto_1fr_2fr_0.6fr_0.9fr_0.7fr_0.9fr_0.9fr_auto] gap-2 text-xs font-medium text-muted-foreground @2xl:grid">
             <span className="w-6" />
             <span>{t('partNumber')}</span>
             <span>{t('name')}</span>

--- a/src/features/vehicles/Components/service-page/UnifiedServiceHeader.tsx
+++ b/src/features/vehicles/Components/service-page/UnifiedServiceHeader.tsx
@@ -3,19 +3,10 @@
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { ButtonGroup } from '@/components/ui/button-group'
+import { IconActionButton } from '@/components/icon-action-button'
 import { cn } from '@/lib/utils'
-import {
-  ArrowLeft,
-  Download,
-  Globe,
-  Loader2,
-  Mail,
-  MessageSquare,
-  Save,
-  Trash2,
-} from 'lucide-react'
+import { ArrowLeft, Download, Globe, Mail, MessageSquare, Save, Trash2 } from 'lucide-react'
 import { statusColors, paymentStatusColors, paymentStatusLabels } from '../service-detail/types'
 
 export type ServiceTab = 'details' | 'images' | 'video' | 'documents' | 'statusReports'
@@ -113,48 +104,39 @@ export function UnifiedServiceHeader({
               {showSaved && !hasUnsavedChanges && (
                 <span className="text-xs font-medium text-green-600 dark:text-green-400">{t('saved')}</span>
               )}
-              <Button type="submit" form="service-record-form" size="sm" disabled={saving} variant={hasUnsavedChanges ? "default" : "outline"} className={hasUnsavedChanges ? "animate-pulse" : ""}>
-                {saving ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-1" />
-                ) : (
-                  <Save className="h-3.5 w-3.5 sm:mr-1" />
-                )}
-                <span className="hidden sm:inline">{t('save')}</span>
-              </Button>
+              <IconActionButton
+                type="submit"
+                form="service-record-form"
+                label={t('save')}
+                icon={Save}
+                loading={saving}
+                variant={hasUnsavedChanges ? 'default' : 'outline'}
+                className={hasUnsavedChanges ? 'animate-pulse' : ''}
+              />
             </>
           )}
           <ButtonGroup>
-            <Button variant="outline" size="sm" onClick={onDownloadPDF} disabled={downloading}>
-              {downloading ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-1" />
-              ) : (
-                <Download className="h-3.5 w-3.5 sm:mr-1" />
-              )}
-              <span className="hidden sm:inline">{t('pdf')}</span>
-            </Button>
-            <Button variant="outline" size="sm" onClick={onShowEmail}>
-              <Mail className="h-3.5 w-3.5 sm:mr-1" />
-              <span className="hidden sm:inline">{t('email')}</span>
-            </Button>
-            <Button variant="outline" size="sm" onClick={onShowShare}>
-              <Globe className="h-3.5 w-3.5 sm:mr-1" />
-              <span className="hidden sm:inline">{t('share')}</span>
-            </Button>
+            <IconActionButton
+              label={t('pdf')}
+              icon={Download}
+              loading={downloading}
+              onClick={onDownloadPDF}
+            />
+            <IconActionButton label={t('email')} icon={Mail} onClick={onShowEmail} />
+            <IconActionButton label={t('share')} icon={Globe} onClick={onShowShare} />
             {hasCustomer && onNotifyCustomer && (
-              <Button variant="outline" size="sm" onClick={onNotifyCustomer}>
-                <MessageSquare className="h-3.5 w-3.5 sm:mr-1" />
-                <span className="hidden sm:inline">{t('notify')}</span>
-              </Button>
+              <IconActionButton
+                label={t('notify')}
+                icon={MessageSquare}
+                onClick={onNotifyCustomer}
+              />
             )}
-            <Button
-              variant="outline"
-              size="sm"
+            <IconActionButton
+              label={t('delete')}
+              icon={Trash2}
               className="text-destructive hover:bg-destructive/10"
               onClick={onDelete}
-            >
-              <Trash2 className="h-3.5 w-3.5 sm:mr-1" />
-              <span className="hidden sm:inline">{t('delete')}</span>
-            </Button>
+            />
           </ButtonGroup>
         </div>
       </div>


### PR DESCRIPTION
Toolbar buttons drop to icons with the label in a tooltip, so a row of actions is the same width in every language. The parts and labor editors now size themselves off their own container rather than the viewport, stacking into labelled cards while narrow, and the work order list keeps a min-width so the columns that survive stay readable.