### PR TITLE
Say what the phone button does

### DIFF
--- a/src/app/(authenticated)/settings/team/team-settings.tsx
+++ b/src/app/(authenticated)/settings/team/team-settings.tsx
@@ -591,14 +591,14 @@ export function TeamSettings({
                           className="h-8 w-8 text-muted-foreground hover:text-foreground"
                           disabled={!canUseApp(member)}
                           onClick={() => handleSetUpApp(member)}
-                          aria-label={t('team.setupApp')}
+                          aria-label={t('team.giveApp')}
                         >
                           <Smartphone className="h-4 w-4" />
                         </Button>
                       </span>
                     </TooltipTrigger>
                     <TooltipContent>
-                      {canUseApp(member) ? t('team.setupApp') : t('team.cannotUseApp')}
+                      {canUseApp(member) ? t('team.giveApp') : t('team.cannotUseApp')}
                     </TooltipContent>
                   </Tooltip>
                 )}


### PR DESCRIPTION
Signing in on the app as a member with the right permissions still fails, because the app needs a technician record as well as permissions. The error said so, but nothing said who fixes it or where, so the way round it was to detour through the Technician role.

- The phone button is labelled **Give them the app** rather than *Set up app*. It works whether or not the person needs a setup code, which the old label implied it did.
- Paired with the app-side change in torqvoice-technician#3, which points the technician at Settings, Team and the phone button beside their name.