### PR TITLE
Print the document's own logo on portal and share-link PDFs

### DIFF
--- a/src/app/api/public/share/quote/[orgId]/[token]/pdf/route.ts
+++ b/src/app/api/public/share/quote/[orgId]/[token]/pdf/route.ts
@@ -11,6 +11,7 @@ import { resolveUploadPath } from '@/lib/resolve-upload-path'
 import { getFeatures } from '@/lib/features'
 import { getTorqvoiceLogoDataUri } from '@/lib/torqvoice-branding'
 import { resolvePortalOrg } from '@/lib/portal-slug'
+import { documentLogoPath } from '@/features/invoice-designer/Lib/documentLogo'
 import { mergeWithDefaults } from '@/features/settings/Schema/invoiceLayoutSchema'
 import { resolveCustomerLocale } from '@/i18n/locale-from-request'
 
@@ -95,7 +96,7 @@ export async function GET(
     }
 
     let logoDataUri: string | undefined
-    const logoPath = settingsMap['workshop.logo']
+    const logoPath = documentLogoPath(settingsMap, 'quote')
     if (logoPath) {
       try {
         const fullPath = resolveUploadPath(logoPath)

--- a/src/features/invoices/Pdf/buildInvoicePdfBuffer.ts
+++ b/src/features/invoices/Pdf/buildInvoicePdfBuffer.ts
@@ -12,7 +12,7 @@
  *   - loading findings and custom fields
  *   - loading workshop settings, organization info and the layout config
  *   - resolving the customer locale and PDF translations
- *   - reading the workshop logo from disk and converting it to a data URI
+ *   - reading the document logo from disk and converting it to a data URI
  *   - optionally generating a Telegram QR code
  *   - resolving Torqvoice branding visibility
  *   - constructing the InvoicePDF React element and rendering it to a buffer
@@ -32,6 +32,7 @@ import { resolveUploadPath } from '@/lib/resolve-upload-path'
 import { getFeatures } from '@/lib/features'
 import { getTorqvoiceLogoDataUri } from '@/lib/torqvoice-branding'
 import { formatDateForPdf } from '@/lib/format'
+import { documentLogoPath } from '@/features/invoice-designer/Lib/documentLogo'
 import { mergeWithDefaults } from '@/features/settings/Schema/invoiceLayoutSchema'
 import { resolveCustomerLocale } from '@/i18n/locale-from-request'
 
@@ -186,7 +187,7 @@ export async function buildInvoicePdfBuffer(
     labels.tax = `${customTaxLabel} ({rate}%)`
   }
 
-  const logoDataUri = await loadLogoDataUri(settingsMap['workshop.logo'])
+  const logoDataUri = await loadLogoDataUri(documentLogoPath(settingsMap, 'invoice'))
 
   const invoiceSettings = {
     bankAccount: settingsMap['invoice.bankAccount'] || '',


### PR DESCRIPTION
The designer lets an invoice or quote carry its own logo, but the portal PDF route, the share-link PDF download, and the public quote PDF still read the company logo directly, so the same document showed different logos depending on where it was downloaded from. All three now resolve the logo through the shared documentLogoPath fallback: the document's own logo when set, the company logo otherwise.