### PR TITLE
Serve tire-hotel, inspection and document files over share links

### DIFF
--- a/src/app/api/public/files/[token]/[...path]/route.ts
+++ b/src/app/api/public/files/[token]/[...path]/route.ts
@@ -31,7 +31,19 @@ export async function GET(
 
   const [category, filename] = segments
 
-  const allowedCategories = ['vehicles', 'inventory', 'services', 'logos', 'quotes']
+  // Every folder a shared document's images and attachments can live in. A
+  // tire-hotel job's photos sat under its own folder, which this list did not
+  // know, so its share link showed every image but those.
+  const allowedCategories = [
+    'vehicles',
+    'inventory',
+    'services',
+    'logos',
+    'quotes',
+    'tire-hotel',
+    'inspections',
+    'documents',
+  ]
   if (!allowedCategories.includes(category)) {
     return NextResponse.json({ error: 'Invalid category' }, { status: 400 })
   }


### PR DESCRIPTION
The public share-link file route only allowed vehicles, inventory, services, logos and quotes, so a tire-hotel job's photos came back 400 on the shared invoice while the PDF showed them fine. The allowlist now covers tire-hotel, inspections and documents as well; a valid share token is still required and only unlocks that organization's own folder.