### PR TITLE
Let the schedule card take a technician off a job

### DIFF
--- a/messages/de/service.json
+++ b/messages/de/service.json
@@ -360,6 +360,7 @@
     "workBay": "Arbeitsplatz",
     "selectWorkBay": "Arbeitsplatz wählen …",
     "noWorkBay": "Kein Arbeitsplatz",
+    "noTechnician": "Ohne Mechaniker",
     "technicians": "Techniker",
     "otherTeamMembers": "Weitere Teammitglieder",
     "makeTechnician": "Macht sie zum Techniker",

--- a/messages/en/service.json
+++ b/messages/en/service.json
@@ -360,6 +360,7 @@
     "workBay": "Work bay",
     "selectWorkBay": "Select work bay...",
     "noWorkBay": "No work bay",
+    "noTechnician": "No technician",
     "technicians": "Technicians",
     "otherTeamMembers": "Other team members",
     "makeTechnician": "Makes them a technician",

--- a/messages/es/service.json
+++ b/messages/es/service.json
@@ -360,6 +360,7 @@
     "workBay": "Puesto de trabajo",
     "selectWorkBay": "Seleccionar puesto…",
     "noWorkBay": "Sin puesto",
+    "noTechnician": "Sin técnico",
     "technicians": "Técnicos",
     "otherTeamMembers": "Otros miembros del equipo",
     "makeTechnician": "Lo convierte en técnico",

--- a/messages/fr/service.json
+++ b/messages/fr/service.json
@@ -360,6 +360,7 @@
     "workBay": "Poste de travail",
     "selectWorkBay": "Choisir un poste…",
     "noWorkBay": "Aucun poste",
+    "noTechnician": "Sans technicien",
     "technicians": "Techniciens",
     "otherTeamMembers": "Autres membres de l’équipe",
     "makeTechnician": "En fait un technicien",

--- a/messages/it/service.json
+++ b/messages/it/service.json
@@ -360,6 +360,7 @@
     "workBay": "Postazione",
     "selectWorkBay": "Seleziona postazione…",
     "noWorkBay": "Nessuna postazione",
+    "noTechnician": "Senza tecnico",
     "technicians": "Tecnici",
     "otherTeamMembers": "Altri membri del team",
     "makeTechnician": "Lo rende un tecnico",

--- a/messages/lt/service.json
+++ b/messages/lt/service.json
@@ -360,6 +360,7 @@
     "workBay": "Darbo vieta",
     "selectWorkBay": "Pasirinkite darbo vietą…",
     "noWorkBay": "Be darbo vietos",
+    "noTechnician": "Be meistro",
     "technicians": "Technikai",
     "otherTeamMembers": "Kiti komandos nariai",
     "makeTechnician": "Padarys jį techniku",

--- a/messages/nb/service.json
+++ b/messages/nb/service.json
@@ -360,6 +360,7 @@
     "workBay": "Arbeidsplass",
     "selectWorkBay": "Velg arbeidsplass …",
     "noWorkBay": "Ingen arbeidsplass",
+    "noTechnician": "Uten mekaniker",
     "technicians": "Teknikere",
     "otherTeamMembers": "Andre i teamet",
     "makeTechnician": "Gjør dem til tekniker",

--- a/messages/nl/service.json
+++ b/messages/nl/service.json
@@ -360,6 +360,7 @@
     "workBay": "Werkplek",
     "selectWorkBay": "Werkplek kiezen…",
     "noWorkBay": "Geen werkplek",
+    "noTechnician": "Zonder monteur",
     "technicians": "Monteurs",
     "otherTeamMembers": "Andere teamleden",
     "makeTechnician": "Maakt hen monteur",

--- a/messages/pl/service.json
+++ b/messages/pl/service.json
@@ -360,6 +360,7 @@
     "workBay": "Stanowisko",
     "selectWorkBay": "Wybierz stanowisko…",
     "noWorkBay": "Bez stanowiska",
+    "noTechnician": "Bez mechanika",
     "technicians": "Technicy",
     "otherTeamMembers": "Pozostali członkowie zespołu",
     "makeTechnician": "Uczyni tę osobę technikiem",

--- a/messages/pt-BR/service.json
+++ b/messages/pt-BR/service.json
@@ -360,6 +360,7 @@
     "workBay": "Baia",
     "selectWorkBay": "Selecionar baia…",
     "noWorkBay": "Sem baia",
+    "noTechnician": "Sem técnico",
     "technicians": "Técnicos",
     "otherTeamMembers": "Outros membros da equipe",
     "makeTechnician": "Torna essa pessoa técnica",

--- a/messages/ru/service.json
+++ b/messages/ru/service.json
@@ -360,6 +360,7 @@
     "workBay": "Пост",
     "selectWorkBay": "Выберите пост…",
     "noWorkBay": "Без поста",
+    "noTechnician": "Без механика",
     "technicians": "Механики",
     "otherTeamMembers": "Другие участники",
     "makeTechnician": "Сделает механиком",

--- a/messages/tr/service.json
+++ b/messages/tr/service.json
@@ -360,6 +360,7 @@
     "workBay": "Çalışma alanı",
     "selectWorkBay": "Çalışma alanı seçin…",
     "noWorkBay": "Çalışma alanı yok",
+    "noTechnician": "Teknisyensiz",
     "technicians": "Teknisyenler",
     "otherTeamMembers": "Diğer ekip üyeleri",
     "makeTechnician": "Onu teknisyen yapar",

--- a/src/__tests__/features/workboard/unassign-technician.test.ts
+++ b/src/__tests__/features/workboard/unassign-technician.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Taking the technician off a service record from the schedule card.
+ *
+ * The card's picker sends a null technician through scheduleJob. The
+ * assignment and the printed copy of the name both have to go, while the bay
+ * and the booked times stay as they were.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/cached-session', () => ({
+  getCachedSession: vi.fn(),
+  getCachedMembership: vi.fn(),
+}))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('@/lib/notification-bus', () => ({ notificationBus: { emit: vi.fn() } }))
+vi.mock('@/features/workboard/Actions/boardActions/mappers', () => ({
+  SERVICE_JOB_SELECT: {},
+  INSPECTION_JOB_SELECT: {},
+  serviceRecordToJob: (sr: unknown) => sr,
+  inspectionToJob: (insp: unknown) => insp,
+}))
+vi.mock('@/lib/db', () => ({
+  db: {
+    user: { findUnique: vi.fn() },
+    technician: { findFirst: vi.fn() },
+    workBay: { findFirst: vi.fn() },
+    serviceRecord: { findFirst: vi.fn(), update: vi.fn() },
+    inspection: { findFirst: vi.fn(), update: vi.fn() },
+  },
+}))
+
+import { getCachedSession, getCachedMembership } from '@/lib/cached-session'
+import { db } from '@/lib/db'
+import { scheduleJob } from '@/features/workboard/Actions/boardActions/scheduling'
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(getCachedSession).mockResolvedValue({
+    user: { id: 'user-a', email: 'a@example.com' },
+  } as any)
+  vi.mocked(getCachedMembership).mockResolvedValue({
+    organizationId: 'org-a',
+    role: 'owner',
+    roleId: null,
+    customRole: null,
+  } as any)
+  vi.mocked(db.user.findUnique).mockResolvedValue({ isSuperAdmin: false } as any)
+  vi.mocked(db.serviceRecord.findFirst).mockResolvedValue({ id: 'sr-a' } as any)
+  vi.mocked(db.serviceRecord.update).mockResolvedValue({ id: 'sr-a' } as any)
+})
+
+describe('scheduleJob with a null technician', () => {
+  it('clears the technician and the printed name, and nothing else', async () => {
+    const result = await scheduleJob({ id: 'sr-a', type: 'serviceRecord', technicianId: null })
+
+    expect(result.success).toBe(true)
+    const { data } = vi.mocked(db.serviceRecord.update).mock.calls[0][0] as any
+    expect(data).toEqual({ technicianId: null, techName: null })
+    expect(vi.mocked(db.technician.findFirst)).not.toHaveBeenCalled()
+  })
+
+  it('still resolves a real technician by name when one is given', async () => {
+    vi.mocked(db.technician.findFirst).mockResolvedValue({ name: 'Kim' } as any)
+
+    await scheduleJob({ id: 'sr-a', type: 'serviceRecord', technicianId: 'tech-1' })
+
+    const { data } = vi.mocked(db.serviceRecord.update).mock.calls[0][0] as any
+    expect(data).toEqual({ technicianId: 'tech-1', techName: 'Kim' })
+  })
+})

--- a/src/features/vehicles/Components/service-edit/ScheduleTimesSection.tsx
+++ b/src/features/vehicles/Components/service-edit/ScheduleTimesSection.tsx
@@ -247,6 +247,28 @@ export function ScheduleTimesSection({
     }
   }
 
+  /**
+   * Take the technician off the job. The bay and the booked times stay: the
+   * work is still planned, it just has nobody's name on it yet.
+   */
+  const handleTechClear = async () => {
+    const previous = selectedTechId
+    setSelectedTechId('')
+    setTechOpen(false)
+    const res = await scheduleJob({
+      id: serviceRecordId,
+      type: 'serviceRecord',
+      technicianId: null,
+    })
+    if (res.success) {
+      onSaved?.()
+      if (startDateTime && endDateTime) void checkSlot(startDateTime, endDateTime, '', bayId)
+    } else {
+      toast.error(res.error || t('failedUpdate'))
+      setSelectedTechId(previous)
+    }
+  }
+
   const handleMemberSelect = async (member: OrgMember) => {
     // Check if a technician already exists for this user
     const existing = technicians.find((t) => t.userId === member.id)
@@ -371,6 +393,17 @@ export function ScheduleTimesSection({
               />
               <CommandList className="max-h-60 overflow-y-auto">
                 <CommandEmpty className="p-0" />
+                {/* The way off the job, the same as the bay select's "No work
+                    bay". Without it a technician could be swapped but never
+                    removed from here. */}
+                <CommandGroup>
+                  <CommandItem value={t('noTechnician')} onSelect={handleTechClear}>
+                    <Check
+                      className={cn('mr-2 h-4 w-4', selectedTechId ? 'opacity-0' : 'opacity-100')}
+                    />
+                    <span className="text-muted-foreground">{t('noTechnician')}</span>
+                  </CommandItem>
+                </CommandGroup>
                 {/* Two different kinds of person, under two headings.
                     They used to share one, so somebody who books cars in read
                     as a mechanic, and choosing them quietly created a


### PR DESCRIPTION
The technician picker on a service record could swap a person but never remove one.

A "No technician" choice now clears the assignment and the printed name while keeping the bay and booked times, in all twelve locales.