### PR TITLE
Copy the next-ws follow-up patch script into the Docker deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma/
 COPY prisma.config.ts ./prisma.config.ts
+# npm ci runs the prepare script, which patches next-ws and then applies our
+# own follow-up patch from scripts/. The source tree is not copied until the
+# builder stage, so that one file has to come along here.
+COPY scripts/patch-next-ws-first-upgrade.mjs ./scripts/
 RUN npm ci
 
 # Rebuild the source code only when needed


### PR DESCRIPTION
#344 made the prepare script run scripts/patch-next-ws-first-upgrade.mjs after next-ws patch, but the deps stage runs npm ci before the source tree is copied, so the image build failed. Copy that one file alongside package.json so prepare can find it.