### PR TITLE
Customer link is undefined

### DIFF
--- a/src/__tests__/lib/app-url.test.ts
+++ b/src/__tests__/lib/app-url.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getAppBaseUrl } from '@/lib/app-url'
+
+/**
+ * A self-hosted install sets NEXT_PUBLIC_APP_URL and has no VERCEL_URL. The
+ * expression this replaced tested the first and printed the second, so every
+ * emailed share link left the building as "https://undefined/share/...".
+ */
+describe('getAppBaseUrl', () => {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL
+  const vercelUrl = process.env.VERCEL_URL
+
+  afterEach(() => {
+    restore('NEXT_PUBLIC_APP_URL', appUrl)
+    restore('VERCEL_URL', vercelUrl)
+  })
+
+  function restore(key: string, value: string | undefined) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+
+  it('uses the configured address on a self-hosted install', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://workshop.example.com'
+    delete process.env.VERCEL_URL
+    expect(getAppBaseUrl()).toBe('https://workshop.example.com')
+  })
+
+  it('never prints undefined when only the configured address is set', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://workshop.example.com'
+    delete process.env.VERCEL_URL
+    expect(getAppBaseUrl()).not.toContain('undefined')
+  })
+
+  it('prefers the configured address over the deployment hostname', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://workshop.example.com'
+    process.env.VERCEL_URL = 'preview-abc123.vercel.app'
+    expect(getAppBaseUrl()).toBe('https://workshop.example.com')
+  })
+
+  it('falls back to the deployment hostname on a preview', () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    process.env.VERCEL_URL = 'preview-abc123.vercel.app'
+    expect(getAppBaseUrl()).toBe('https://preview-abc123.vercel.app')
+  })
+
+  it('falls back to localhost when nothing is configured', () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    delete process.env.VERCEL_URL
+    expect(getAppBaseUrl()).toBe('http://localhost:3000')
+  })
+
+  it('does not leave a trailing slash to double up on the path', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://workshop.example.com/'
+    delete process.env.VERCEL_URL
+    expect(`${getAppBaseUrl()}/share/invoice/org/token`).toBe(
+      'https://workshop.example.com/share/invoice/org/token'
+    )
+  })
+
+  it('ignores an address set to whitespace', () => {
+    process.env.NEXT_PUBLIC_APP_URL = '   '
+    delete process.env.VERCEL_URL
+    expect(getAppBaseUrl()).toBe('http://localhost:3000')
+  })
+})

--- a/src/__tests__/lib/app-url.test.ts
+++ b/src/__tests__/lib/app-url.test.ts
@@ -58,6 +58,20 @@ describe('getAppBaseUrl', () => {
     )
   })
 
+  it("uses the caller's fallback when nothing is configured", () => {
+    // The portal verify route sends people back to the address that reached
+    // it, which beats guessing at the dev server.
+    delete process.env.NEXT_PUBLIC_APP_URL
+    delete process.env.VERCEL_URL
+    expect(getAppBaseUrl('https://portal.example.com')).toBe('https://portal.example.com')
+  })
+
+  it("still prefers the configured address over the caller's fallback", () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://workshop.example.com'
+    delete process.env.VERCEL_URL
+    expect(getAppBaseUrl('https://portal.example.com')).toBe('https://workshop.example.com')
+  })
+
   it('ignores an address set to whitespace', () => {
     process.env.NEXT_PUBLIC_APP_URL = '   '
     delete process.env.VERCEL_URL

--- a/src/app/(authenticated)/settings/customer-portal/page.tsx
+++ b/src/app/(authenticated)/settings/customer-portal/page.tsx
@@ -9,6 +9,7 @@ import {
   isValidPortalBackgroundType,
   type PortalBackgroundType,
 } from '@/features/portal/portal-backgrounds'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 export default async function CustomerPortalSettingsPage() {
   const data = await getLayoutData()
@@ -53,9 +54,7 @@ export default async function CustomerPortalSettingsPage() {
 
   const settingMap = new Map(settings.map((s) => [s.key, s.value]))
 
-  const appUrl =
-    process.env.NEXT_PUBLIC_APP_URL ||
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  const appUrl = getAppBaseUrl()
 
   const rawBgType = settingMap.get(SETTING_KEYS.PORTAL_BACKGROUND_TYPE)
   const backgroundType: PortalBackgroundType = isValidPortalBackgroundType(rawBgType)

--- a/src/app/(public)/portal/[orgId]/auth/verify/route.ts
+++ b/src/app/(public)/portal/[orgId]/auth/verify/route.ts
@@ -3,19 +3,14 @@ import { randomBytes } from 'crypto'
 import { db } from '@/lib/db'
 import { CUSTOMER_SESSION_COOKIE, CUSTOMER_SESSION_DURATION } from '@/lib/customer-session'
 import { resolvePortalOrg } from '@/lib/portal-slug'
-
-function getBaseUrl(requestUrl: string): string {
-  // Prefer configured app URL, fall back to request origin
-  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`
-  return new URL(requestUrl).origin
-}
+import { getAppBaseUrl } from '@/lib/app-url'
 
 export async function GET(request: Request, { params }: { params: Promise<{ orgId: string }> }) {
   const { orgId: orgParam } = await params
   const { searchParams } = new URL(request.url)
   const token = searchParams.get('token')
-  const baseUrl = getBaseUrl(request.url)
+  // Nothing configured: the address that reached us is the one to send them back to.
+  const baseUrl = getAppBaseUrl(new URL(request.url).origin)
 
   const loginUrl = `${baseUrl}/portal/${orgParam}/auth/login`
 

--- a/src/app/(public)/share/inspection/[orgId]/[token]/page.tsx
+++ b/src/app/(public)/share/inspection/[orgId]/[token]/page.tsx
@@ -4,6 +4,7 @@ import { InspectionView } from './inspection-view'
 import { getFeatures } from '@/lib/features'
 import { resolvePortalOrg } from '@/lib/portal-slug'
 import type { Metadata } from 'next'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 export const revalidate = 60
 
@@ -106,9 +107,7 @@ export default async function PublicInspectionPage({
 
   const primaryColor = settingsMap['invoice.primaryColor'] || '#d97706'
 
-  const appUrl =
-    process.env.NEXT_PUBLIC_APP_URL ||
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  const appUrl = getAppBaseUrl()
   const portalSlug = org?.portalSlug
   const portalEnabled = settingsMap['portal.enabled'] === 'true'
   const portalUrl = portalEnabled ? `${appUrl}/portal/${portalSlug || orgId}` : undefined

--- a/src/app/(public)/share/invoice/[orgId]/[token]/page.tsx
+++ b/src/app/(public)/share/invoice/[orgId]/[token]/page.tsx
@@ -12,6 +12,7 @@ import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { getOrgTelegramBotUsername } from '@/lib/telegram'
 import { offeredPaymentProviders } from '@/features/integrations/Lib/payments'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 /** Rewrites /api/protected/files/[orgId]/[category]/[filename] to /api/public/files/[token]/[category]/[filename] */
 function toPublicFileUrl(fileUrl: string, token: string): string {
@@ -130,9 +131,7 @@ export default async function PublicInvoicePage({
     settingsMap['payment.termsOfSaleUrl'] ||
     (settingsMap['payment.termsOfSale'] ? `/share/terms/${orgId}` : undefined)
 
-  const appUrl =
-    process.env.NEXT_PUBLIC_APP_URL ||
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  const appUrl = getAppBaseUrl()
   const portalSlug = org?.portalSlug
   const portalEnabled = settingsMap['portal.enabled'] === 'true'
   const portalUrl = portalEnabled ? `${appUrl}/portal/${portalSlug || orgId}` : undefined

--- a/src/app/(public)/share/quote/[orgId]/[token]/page.tsx
+++ b/src/app/(public)/share/quote/[orgId]/[token]/page.tsx
@@ -12,6 +12,7 @@ import { getTorqvoiceLogoDataUri } from '@/lib/torqvoice-branding'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { getCustomFieldsForPrint } from '@/features/custom-fields/Lib/getCustomFieldsForPrint'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 export const revalidate = 60
 
@@ -223,9 +224,7 @@ export default async function PublicQuotePage({
     layoutConfig,
   })
 
-  const appUrl =
-    process.env.NEXT_PUBLIC_APP_URL ||
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  const appUrl = getAppBaseUrl()
   const portalSlug = org?.portalSlug
   const portalEnabled = settingsMap['portal.enabled'] === 'true'
   const portalUrl = portalEnabled ? `${appUrl}/portal/${portalSlug || orgId}` : undefined

--- a/src/app/api/protected/services/[id]/pdf/route.ts
+++ b/src/app/api/protected/services/[id]/pdf/route.ts
@@ -15,6 +15,7 @@ import { markInvoiceIssued } from '@/features/onboarding/Lib/markInvoiceIssued'
 import { getOrgTelegramBotUsername } from '@/lib/telegram'
 import { loadPrintLabels } from '@/features/invoice-designer/Pdf/printLabels'
 import { assembleInvoicePrint, invoiceNumberOf } from '@/features/invoices/Lib/assembleInvoicePrint'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -101,9 +102,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
       torqvoiceLogoDataUri = await getTorqvoiceLogoDataUri()
     }
 
-    const appUrl =
-      process.env.NEXT_PUBLIC_APP_URL ||
-      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+    const appUrl = getAppBaseUrl()
     const portalSlug = org?.portalSlug
     const portalEnabled = settingsMap['portal.enabled'] === 'true'
     const portalUrl = portalEnabled

--- a/src/app/api/public/portal/[orgId]/auth/request/route.ts
+++ b/src/app/api/public/portal/[orgId]/auth/request/route.ts
@@ -6,6 +6,7 @@ import { sendOrgMail, getOrgFromAddress } from '@/lib/email'
 import { SETTING_KEYS } from '@/features/settings/Schema/settingsSchema'
 import { MAGIC_LINK_DURATION } from '@/lib/customer-session'
 import { resolvePortalOrg } from '@/lib/portal-slug'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 function escapeHtml(value: string): string {
   return value
@@ -80,9 +81,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ org
     })
 
     // Send email - use the URL param (slug) so the verify link matches the user's URL
-    const appUrl =
-      process.env.NEXT_PUBLIC_APP_URL ||
-      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+    const appUrl = getAppBaseUrl()
 
     const magicLinkUrl = `${appUrl}/portal/${orgParam}/auth/verify?token=${token}`
     const fromAddress = await getOrgFromAddress(orgId)

--- a/src/app/api/public/share/inspection/[orgId]/[token]/pdf/route.ts
+++ b/src/app/api/public/share/inspection/[orgId]/[token]/pdf/route.ts
@@ -12,6 +12,7 @@ import { getFeatures } from '@/lib/features'
 import { getTorqvoiceLogoDataUri } from '@/lib/torqvoice-branding'
 import { resolvePortalOrg } from '@/lib/portal-slug'
 import { resolveCustomerLocale } from '@/i18n/locale-from-request'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 export async function GET(
   _request: Request,
@@ -124,9 +125,7 @@ export async function GET(
       headerStyle: settingsMap['invoice.headerStyle'] || 'standard',
     }
 
-    const appUrl =
-      process.env.NEXT_PUBLIC_APP_URL ||
-      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+    const appUrl = getAppBaseUrl()
     const portalSlug = org?.portalSlug
     const portalEnabled = settingsMap['portal.enabled'] === 'true'
     const portalUrl = portalEnabled ? `${appUrl}/portal/${portalSlug || orgId}` : undefined

--- a/src/app/api/public/share/quote/[orgId]/[token]/pdf/route.ts
+++ b/src/app/api/public/share/quote/[orgId]/[token]/pdf/route.ts
@@ -15,6 +15,7 @@ import { documentLogoPath } from '@/features/invoice-designer/Lib/documentLogo'
 import { mergeWithDefaults } from '@/features/settings/Schema/invoiceLayoutSchema'
 import { resolveCustomerLocale } from '@/i18n/locale-from-request'
 import { getCustomFieldsForPrint } from '@/features/custom-fields/Lib/getCustomFieldsForPrint'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 export async function GET(
   _request: Request,
@@ -204,9 +205,7 @@ export async function GET(
       logoSize: Number(settingsMap['quote.logoSize']) || 100,
     }
 
-    const appUrl =
-      process.env.NEXT_PUBLIC_APP_URL ||
-      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+    const appUrl = getAppBaseUrl()
     const portalSlug = org?.portalSlug
     const portalEnabled = settingsMap['portal.enabled'] === 'true'
     const portalUrl = portalEnabled ? `${appUrl}/portal/${portalSlug || orgId}` : undefined

--- a/src/features/email/Actions/emailActions.ts
+++ b/src/features/email/Actions/emailActions.ts
@@ -26,6 +26,7 @@ import { issueInvoice } from '@/features/invoices/Lib/issueInvoice'
 import { assembleInvoicePrint, invoiceNumberOf } from '@/features/invoices/Lib/assembleInvoicePrint'
 import { loadPrintLabels } from '@/features/invoice-designer/Pdf/printLabels'
 import { resolveCustomerLocale } from '@/i18n/locale-from-request'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 async function getWorkshopSettings(organizationId: string) {
   const [settings, org] = await Promise.all([
@@ -319,7 +320,7 @@ export async function sendInvoiceEmail(input: {
 
       // Build public invoice link if token exists
       const publicLink = owned.publicToken
-        ? `${process.env.NEXT_PUBLIC_APP_URL || process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000'}/share/invoice/${organizationId}/${owned.publicToken}`
+        ? `${getAppBaseUrl()}/share/invoice/${organizationId}/${owned.publicToken}`
         : null
 
       const from = await getOrgFromAddress(organizationId)
@@ -459,7 +460,7 @@ export async function sendInspectionEmail(input: {
 
       // Build public link if token exists
       const publicLink = inspection.publicToken
-        ? `${process.env.NEXT_PUBLIC_APP_URL || process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000'}/share/inspection/${organizationId}/${inspection.publicToken}`
+        ? `${getAppBaseUrl()}/share/inspection/${organizationId}/${inspection.publicToken}`
         : null
 
       const from = await getOrgFromAddress(organizationId)

--- a/src/features/invoices/Pdf/buildInvoicePdfBuffer.ts
+++ b/src/features/invoices/Pdf/buildInvoicePdfBuffer.ts
@@ -21,6 +21,7 @@ import { getTorqvoiceLogoDataUri } from '@/lib/torqvoice-branding'
 import { resolveCustomerLocale } from '@/i18n/locale-from-request'
 import { loadPrintLabels } from '@/features/invoice-designer/Pdf/printLabels'
 import { assembleInvoicePrint, invoiceNumberOf } from '../Lib/assembleInvoicePrint'
+import { getAppBaseUrl } from '@/lib/app-url'
 
 export async function buildInvoicePdfBuffer(
   serviceRecordId: string,
@@ -40,9 +41,7 @@ export async function buildInvoicePdfBuffer(
     torqvoiceLogoDataUri = await getTorqvoiceLogoDataUri()
   }
 
-  const appUrl =
-    process.env.NEXT_PUBLIC_APP_URL ||
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  const appUrl = getAppBaseUrl()
   const portalSlug = org?.portalSlug
   const portalEnabled = settingsMap['portal.enabled'] === 'true'
   const portalUrl = portalEnabled ? `${appUrl}/portal/${portalSlug || orgId}` : undefined

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -1,0 +1,19 @@
+/**
+ * The address this installation answers on, for links built on the server.
+ *
+ * A link the browser builds can use window.location.origin and is always
+ * right. A link an email or a PDF builds has no browser to ask, so it has to
+ * be told: NEXT_PUBLIC_APP_URL is that address on a self-hosted install, and
+ * VERCEL_URL stands in on a preview deployment, which has no fixed hostname.
+ *
+ * Written down once because the expression is easy to get wrong: `a || b ? c
+ * : d` reads as `(a || b) ? c : d`, which tests one address and then prints
+ * the other. That typo sent every emailed share link out as
+ * "https://undefined/share/..." on installations that are not on Vercel.
+ */
+export function getAppBaseUrl(): string {
+  const configured = process.env.NEXT_PUBLIC_APP_URL?.trim()
+  if (configured) return configured.replace(/\/+$/, '')
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`
+  return 'http://localhost:3000'
+}

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -10,10 +10,15 @@
  * : d` reads as `(a || b) ? c : d`, which tests one address and then prints
  * the other. That typo sent every emailed share link out as
  * "https://undefined/share/..." on installations that are not on Vercel.
+ *
+ * `fallback` is what to use when neither is configured. It defaults to the
+ * dev server, which is the right guess for a link built while someone is
+ * working locally; a request handler that knows the origin it was called on
+ * should pass that instead, since it is the address that actually reached us.
  */
-export function getAppBaseUrl(): string {
+export function getAppBaseUrl(fallback = 'http://localhost:3000'): string {
   const configured = process.env.NEXT_PUBLIC_APP_URL?.trim()
   if (configured) return configured.replace(/\/+$/, '')
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`
-  return 'http://localhost:3000'
+  return fallback
 }


### PR DESCRIPTION
A user reported that emailing an invoice share link delivered `https://undefined/share/...`, while the link shown in the share dialog was fine.

## Cause

`emailActions.ts` built the address from:

```js
process.env.NEXT_PUBLIC_APP_URL || process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000'
```

`||` binds tighter than the ternary, so this reads as `(NEXT_PUBLIC_APP_URL || VERCEL_URL) ? ... : ...`. It checks whether either address is set and then interpolates `VERCEL_URL` regardless. Outside Vercel that variable does not exist, so the link went out as `https://undefined/share/...` on every self-hosted installation, whatever `NEXT_PUBLIC_APP_URL` was set to.

The dialog looked correct because the browser builds that link from `window.location.origin`, and SMS carries the browser's copy, so only the emailed link was wrong.

## Fix

New `getAppBaseUrl()` in `src/lib/app-url.ts`: prefer the configured address, fall back to the deployment hostname on a Vercel preview, then to a caller-supplied fallback that defaults to localhost. Trailing slashes are trimmed so a configured `https://host/` does not produce a double slash.

Both broken sites now use it: the invoice share link and the inspection share link.

## Also in this PR

The same expression was written out by hand in ten other places. All of them were parenthesised correctly and none were broken, but the typo was one careless edit away from returning, so they now call the helper too: the three share pages, the three share PDF routes, the service PDF route, the portal auth request route, the customer portal settings page and `buildInvoicePdfBuffer`.

The portal verify route kept its own fallback to the origin the request arrived on, which is a better guess than the dev server for a redirect, so the helper takes the fallback as an argument. No `VERCEL_URL` reference is left outside the helper.

## Testing

- New unit tests in `src/__tests__/lib/app-url.test.ts`: the self-hosted case that was broken, precedence between the two variables, all three fallbacks, the caller-supplied fallback, the trailing slash and a whitespace-only value.
- Full suite green (193 files, 2937 tests), `npx tsc --noEmit` clean, biome clean.
