### PR TITLE
Billing list does not remember its sort order

### DIFF
--- a/src/app/(authenticated)/billing/billing-client.tsx
+++ b/src/app/(authenticated)/billing/billing-client.tsx
@@ -34,6 +34,7 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useFormatCurrency } from '@/components/currency-settings-context'
+import { useRememberedSort } from '@/hooks/use-remembered-sort'
 
 interface BillingRecord {
   id: string
@@ -105,6 +106,7 @@ export default function BillingClient({
   const searchParams = useSearchParams()
   const [isPending, startTransition] = useTransition()
   const tableNav = useTableKeyboardNav()
+  useRememberedSort('billing')
 
   const createQueryString = useCallback(
     (params: Record<string, string>) => {

--- a/src/app/(authenticated)/billing/page.tsx
+++ b/src/app/(authenticated)/billing/page.tsx
@@ -1,3 +1,4 @@
+import { resolveListSort } from '@/lib/list-sort-preference.server'
 import { getBillingHistory } from '@/features/billing/Actions/billingActions'
 import { getSettings } from '@/features/settings/Actions/settingsActions'
 import { SETTING_KEYS } from '@/features/settings/Schema/settingsSchema'
@@ -22,8 +23,11 @@ export default async function BillingPage({
   const pageSize = Number(params.pageSize) || 20
   const search = params.search || ''
   const statusFilter = params.status || 'all'
-  const sortBy = params.sortBy || ''
-  const sortOrder = (params.sortOrder as 'asc' | 'desc') || 'desc'
+  // No column asked for anywhere means the list keeps its own default, which
+  // getBillingHistory reads as newest first.
+  const sort = await resolveListSort('billing', params, { sortBy: undefined, sortOrder: 'desc' })
+  const sortBy = sort.sortBy || ''
+  const sortOrder = sort.sortOrder
 
   const [result, settingsResult] = await Promise.all([
     getBillingHistory({ page, pageSize, search, status: statusFilter, sortBy, sortOrder }),

--- a/src/lib/list-sort-preference.ts
+++ b/src/lib/list-sort-preference.ts
@@ -20,6 +20,7 @@ export type ListKey =
   | 'inventory'
   | 'inspections'
   | 'laborPresets'
+  | 'billing'
 
 export const LIST_SORT_COOKIE = 'listSort'
 


### PR DESCRIPTION
Sorting the billing list only lived in the URL, so returning to a bare `/billing` reverted to newest first. Every other list keeps its column in the `listSort` cookie.

Billing now uses the same helpers: `resolveListSort` on the server and `useRememberedSort` in the client. URL wins, then the remembered column, then newest first.